### PR TITLE
Rename predicate calculus axioms (without moving them) per 20-Dec-2018

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -4566,7 +4566,7 @@ axioms (although they are equivalent in a ``logical'' sense) and the
 ones I have chosen at least do the job.  Perhaps a logician who reads
 this would be interested in devising a set of equivalent axioms that are
 shorter or more elegant in some sense.\index{axioms in \texttt{set.mm}}
-(For example, there used to be an axiom \texttt{ax-15} in our list that
+(For example, there used to be an axiom \texttt{ax-c14} in our list that
 was later discovered to be redundant in this version of the axiom
 system.  The Comment on p.~\pageref{nodd} has a further remark on this axiom.)
 
@@ -4653,7 +4653,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Specialization.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-4\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-c5\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\forall}\m{x}\m{\varphi}\m{\rightarrow}\m{\varphi}\m{)}
@@ -4661,7 +4661,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Quantified Implication.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-5\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-4\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\forall}\m{x}\m{(}\m{\forall}\m{x}\m{\varphi}\m{\rightarrow}\m{
@@ -4671,7 +4671,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Quantified Negation.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-6\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-10\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\lnot}\m{\forall}\m{x}\m{\lnot}\m{\forall}\m{x}\m{\varphi}\m{
@@ -4680,7 +4680,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Quantifier Commutation.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-7\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-11\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\forall}\m{x}\m{\forall}\m{y}\m{\varphi}\m{\rightarrow}\m{
@@ -4707,7 +4707,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Equality (1).
 
-\setbox\startprefix=\hbox{\tt \ \ ax-8\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-7\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{x}\m{=}\m{y}\m{\rightarrow}\m{(}\m{x}\m{=}\m{z}\m{
@@ -4716,7 +4716,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Existence.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-9\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-6\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\forall}\m{x}\m{(}\m{x}\m{=}\m{y}\m{\rightarrow}\m{\forall}
@@ -4725,7 +4725,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Quantifier Substitution.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-10\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-c11n\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\forall}\m{x}\m{\,x}\m{=}\m{y}\m{\rightarrow}\m{(}\m{\forall}
@@ -4735,7 +4735,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Variable Substitution.
 
-\setbox\startprefix=\hbox{\tt \ \ ax-11\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-12\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\lnot}\m{\forall}\m{x}\m{\,x}\m{=}\m{y}\m{\rightarrow}\m{(}
@@ -4745,7 +4745,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Quantifier Introduction (1).
 
-\setbox\startprefix=\hbox{\tt \ \ ax-12\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-13\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\lnot}\m{\forall}\m{z}\m{\,z}\m{=}\m{x}\m{\rightarrow}\m{(}
@@ -4755,7 +4755,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Equality (2).
 
-\setbox\startprefix=\hbox{\tt \ \ ax-13\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-8\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{x}\m{=}\m{y}\m{\rightarrow}\m{(}\m{x}\m{\in}\m{z}\m{
@@ -4764,7 +4764,7 @@ Axiom of Simplification.\label{ax1}
 
 \noindent Axiom of Equality (3).
 
-\setbox\startprefix=\hbox{\tt \ \ ax-14\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-9\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{x}\m{=}\m{y}\m{\rightarrow}\m{(}\m{z}\m{\in}\m{x}\m{
@@ -4782,7 +4782,7 @@ variables}.)
 \m{x}\m{\,}\m{y}
 \endm
 
-\setbox\startprefix=\hbox{\tt \ \ ax-16\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-c16\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\forall}\m{x}\m{\,x}\m{=}\m{y}\m{\rightarrow}\m{(}\m{\varphi}\m{
@@ -4798,7 +4798,7 @@ wff\index{\texttt{\$d} statement}\index{distinct variables}.)
 \startm
 \m{x}\m{\,}\m{\varphi}
 \endm
-\setbox\startprefix=\hbox{\tt \ \ ax-17\ \$a\ }
+\setbox\startprefix=\hbox{\tt \ \ ax-5\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
 \startm
 \m{\vdash}\m{(}\m{\varphi}\m{\rightarrow}\m{\forall}\m{x}\m{\varphi}\m{)}
@@ -4825,9 +4825,9 @@ equivalence ($\leftrightarrow$)}\index{biconditional ($\leftrightarrow$)} and
 In addition, the axioms of set theory require that all variables be
 dis\-tinct,\index{distinct variables}\footnote{Set theory axioms can be
 devised so that {\em no} variables are required to be distinct,
-provided we replace \texttt{ax-16} with an axiom stating that ``at
+provided we replace \texttt{ax-c16} with an axiom stating that ``at
 least two things exist,'' thus
-making \texttt{ax-17} the only other axiom requiring the
+making \texttt{ax-5} the only other axiom requiring the
 \texttt{\$d} statement.  These axioms are unconventional and are not
 presented here, but they can be found on the \url{http://metamath.org}
 web site.  See also the Comment on
@@ -8228,28 +8228,28 @@ theorem that has this requirement.
 \begin{verbatim}
 MM> verify proof ax17eq
 ax17eq ?Error at statement 1918, label "ax17eq", type "$p":
-      vz wal wi vx vy vz ax-12 vx vy weq vz vx ax-16 vx vy
+      vz wal wi vx vy vz ax-13 vx vy weq vz vx ax-c16 vx vy
                                                ^^^^^
 There is a disjoint variable ($d) violation at proof step 29.
-Assertion "ax-16" requires that variables "x" and "y" be
+Assertion "ax-c16" requires that variables "x" and "y" be
 disjoint.  But "x" was substituted with "z" and "y" was
 substituted with "x".  The assertion being proved, "ax17eq",
 does not require that variables "z" and "x" be disjoint.
 \end{verbatim}
 
-We can see the substitutions into \texttt{ax-16} with the following command.
+We can see the substitutions into \texttt{ax-c16} with the following command.
 
 \begin{verbatim}
 MM> show proof ax17eq / detailed_step 29
-Proof step 29:  pm2.61dd.2=ax-16 $a |- ( A. z z = x -> ( x =
+Proof step 29:  pm2.61dd.2=ax-c16 $a |- ( A. z z = x -> ( x =
   y -> A. z x = y ) )
-This step assigns source "ax-16" ($a) to target "pm2.61dd.2"
+This step assigns source "ax-c16" ($a) to target "pm2.61dd.2"
 ($e).  The source assertion requires the hypotheses "wph"
 ($f, step 26), "vx" ($f, step 27), and "vy" ($f, step 28).
 The parent assertion of the target hypothesis is "pm2.61dd"
 ($p, step 36).
 The source assertion before substitution was:
-    ax-16 $a |- ( A. x x = y -> ( ph -> A. x ph ) )
+    ax-c16 $a |- ( A. x x = y -> ( ph -> A. x ph ) )
 The following substitutions were made to the source
 assertion:
     Variable  Substituted with
@@ -8265,16 +8265,16 @@ hypothesis:
      ch        ( x = y -> A. z x = y )
 \end{verbatim}
 
-The disjoint variable restrictions of \texttt{ax-16} can be seen from the
+The disjoint variable restrictions of \texttt{ax-c16} can be seen from the
 \texttt{show state\-ment} command.  The line that begins ``\texttt{Its mandatory
 dis\-joint var\-i\-able pairs are:}\ldots'' lists any \texttt{\$d} variable
 pairs in brackets.
 
 \begin{verbatim}
-MM> show statement ax-16/full
+MM> show statement ax-c16/full
 Statement 3033 is located on line 9338 of the file "set.mm".
 "Axiom of Distinct Variables. ..."
-  ax-16 $a |- ( A. x x = y -> ( ph -> A. x ph ) ) $.
+  ax-c16 $a |- ( A. x x = y -> ( ph -> A. x ph ) ) $.
 Its mandatory hypotheses in RPN order are:
   wph $f wff ph $.
   vx $f set x $.
@@ -8296,7 +8296,7 @@ On the other hand, when you introduce axioms (\texttt{\$a}\index{\texttt{\$a}
 statement} statements), you must be very careful to properly specify the
 necessary associated \texttt{\$d} statements since Metamath has no way of knowing
 whether your axioms are correct.  For example, Metamath would have no idea
-that \texttt{ax-16}, which we are telling it is an axiom of logic, would lead to
+that \texttt{ax-c16}, which we are telling it is an axiom of logic, would lead to
 contradictions if we omitted its associated \texttt{\$d} statement.
 
 {\footnotesize\begin{quotation}\label{nodd}
@@ -8316,7 +8316,7 @@ trick there is simply to embed harmlessly the necessary dummy variables into a
 theorem being proved so that they aren't ``dummy'' anymore, then interpret the
 resulting longer theorem so as to ignore the embedded dummy variables.  If
 this interests you, the system in \texttt{set.mm} obtained from \texttt{ax-1}
-through \texttt{ax-15} in \texttt{set.mm}, and deleting \texttt{ax-16} and \texttt{ax-17},
+through \texttt{ax-c14} in \texttt{set.mm}, and deleting \texttt{ax-c16} and \texttt{ax-5},
 requires no \texttt{\$d} statements but is logically complete in the sense
 described in \cite{Megill}.  This means it can prove any theorem of
 first-order logic as long as we add to the theorem an antecedent that embeds


### PR DESCRIPTION
On 20-Dec-2018, the predicate calculus axiom schemes were renumbered to
eliminate gaps caused by obsolete or redundant axiom schemes, as well
as to order them according to their current organization. Older papers,
slide presentations, and websites may reference the old numbering.
The renumbering is shown in:
http://us.metamath.org/mpeuni/mmset.html#oldaxioms

This commit renames the axioms in the book, *without* moving them so
that it is easier to see exactly what names changed.

This is a first among a number of steps to update the metamath book so
that the book and actual set.mm file correspond.  We rename the axioms
*first*, in place, to ensure that all later changes will consistently
use the new names.  This will also make it easier to notice when things
are not in the new (intended) order.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>