### PR TITLE
Note that directory pathname processing isn't defined, fixes #28

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -7460,11 +7460,9 @@ Included files may not include a \texttt{\$(} without a matching \texttt{\$)},
 may not include a \texttt{\$[} without a matching \texttt{\$]}, and may
 not include incomplete statements (e.g., a \texttt{\$a} without a matching
 \texttt{\$.}).
-It is unspecified if path references are relative to the process'
+It is currently unspecified if path references are relative to the process'
 current directory or the file's containing directory, so databases should
-avoid using pathname separators in file names
-(use underscores to separate semantic levels; if pathname separators are
-necessary use the more-portable "/").
+avoid using pathname separators (e.g., "/") in file names.
 
 Like all tokens, the \texttt{\$(}, \texttt{\$)}, \texttt{\$[}, and \texttt{\$]} keywords
 must be surrounded by white space.

--- a/metamath.tex
+++ b/metamath.tex
@@ -7447,13 +7447,12 @@ It is only allowed in the outermost scope (i.e., not between
 and must not be inside of a statement (e.g., it may not occur
 between the label of a \texttt{\$a} statement and its \texttt{\$.}).
 The file name may not
-contain a \texttt{\$} or white space.  The file must exist, and is
-relative to the current directory (which might not be the directory
-containing the verifier).  The case-sensitivity
+contain a \texttt{\$} or white space.  The file must exist.
+The case-sensitivity
 of its name follows the conventions of the operating system.  The contents of
 the file replace the inclusion command.
-Included files may include other
-files. Only the first reference to a given file is included; any later
+Included files may include other files.
+Only the first reference to a given file is included; any later
 references to the same file (whether in the top-level file or in included
 files) cause the inclusion command to be ignored (treated like white space).
 A file self-reference is ignored, as is any reference to the top-level file.
@@ -7461,6 +7460,11 @@ Included files may not include a \texttt{\$(} without a matching \texttt{\$)},
 may not include a \texttt{\$[} without a matching \texttt{\$]}, and may
 not include incomplete statements (e.g., a \texttt{\$a} without a matching
 \texttt{\$.}).
+It is unspecified if path references are relative to the process'
+current directory or the file's containing directory, so databases should
+avoid using pathname separators in file names
+(use underscores to separate semantic levels; if pathname separators are
+necessary use the more-portable "/").
 
 Like all tokens, the \texttt{\$(}, \texttt{\$)}, \texttt{\$[}, and \texttt{\$]} keywords
 must be surrounded by white space.


### PR DESCRIPTION
Expressly make directory pathname processing unspecified, and
explain what to do instead. For more information, see:

- https://github.com/metamath/metamath-book/issues/28
- https://groups.google.com/d/msg/metamath/eI0PE0nPOm0/f8_btXt4AgAJ

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>