### PR TITLE
Add the ability to generate metamath-narrow.pdf for smartphones etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,15 @@ note = {{\tt http://us.metamath.org/downloads/metamath.pdf}},
 
 ## Narrow width screens
 
-An old version of this book was generated specifically for
+You can run ./make-narrow to generate "metamath-narrow.pdf",
+a version of the PDF formatted for
 narrow-width screens (such as mobile phones).
-It was called the "Kindle version".
+The program erases metamath.pdf, so you'll need to regenerate metamath.pdf
+afterwards if you want it.
+
+That work is based on
+an old version of this book that was generated specifically for
+narrow-width screens called the "Kindle version".
 The changes that implemented the Kindle version are in
-file kindle-changes.patch.
-We intend to investigate if there's still a need for a special
-version of the PDF for narrow-width screens, and if so, how to do it.
-The information in that old patch may help us get there.
-If you'd like to help, please let us know!
+file kindle-changes.patch.  We keep the .patch file around so that
+we can borrow future ideas in the future.

--- a/make-narrow
+++ b/make-narrow
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Make metamath-narrow.pdf
+# WARNING: This erases metamath.pdf and special-settings.sty
+
+cp -p narrow.sty special-settings.sty
+
+./generate-pdf
+mv metamath.pdf metamath-narrow.pdf
+
+rm -f special-settings.sty
+touch special-settings.sty

--- a/metamath.tex
+++ b/metamath.tex
@@ -661,10 +661,11 @@
 % A book template example
 % http://www.stsci.edu/ftp/software/tex/bookstuff/book.template
 
-%\documentstyle[leqno]{book} % LaTeX 2.09 - obsolete
-\documentclass[leqno]{book} % LaTeX 2e
+\documentclass[leqno]{book} % LaTeX 2e. 10pt. Use [leqno,12pt] for 12pt
 % hyperref 2002/05/27 v6.72r  (couldn't get pagebackref to work)
 \usepackage[plainpages=false,pdfpagelabels=true]{hyperref}
+\usepackage{breqn}         % automatic equation breaking
+\usepackage{microtype}     % microtypography, reduces hyphenation
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Uncomment the next 3 lines to suppress boxes and colors on the hyperlinks
@@ -702,6 +703,9 @@
 % l/r 0.85in&0.6431-0.6539 works t/b ?-?
 %\marginsize{0.85in}{0.6485in}{0.55in}{0.35in}
 \marginsize{0.8in}{0.65in}{0.5in}{0.3in}
+
+% \usepackage[papersize={3.6in,4.8in},hmargin=0.1in,vmargin={0.1in,0.1in}]{geometry}  % page geometry
+\usepackage{special-settings}
 
 \raggedbottom
 \makeindex

--- a/narrow.sty
+++ b/narrow.sty
@@ -1,0 +1,4 @@
+% Settings to generate PDF for a narrow display (e.g. a smartphone).
+% Copy this file to special-settings.sty to use it.
+
+\usepackage[papersize={3.6in,4.8in},hmargin=0.1in,vmargin={0.1in,0.1in}]{geometry}  % page geometry


### PR DESCRIPTION
Today *many* people have smartphones, but the traditional wide
formatting doesn't work so well on them.  PDF supports reflowing,
but LaTeX tools don't support generating PDFs with varying width
so well.

Simple solution: make it easy to create metamath-narrow.pdf, which
is the same document formatted for a narrower screen.
This is a partial extraction from kindle-changes.patch, though we
currently don't do everything it did.  In the future we may extract
more, or do more things; this is simply a minimal version that makes
things work.

There may be other ways to solve this long-term, but this "gets it done".

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>