### PR TITLE
Discourage page widows and orphans. Fixes #18

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -711,6 +711,9 @@
 \makeindex
 
 \begin{document}
+% Discourage page widows and orphans:
+\clubpenalty=300
+\widowpenalty=300
 
 %%%%%%% load in AMS fonts %%%%%%% % LaTeX 2.09 - obsolete in LaTeX 2e
 %\input{amssym.def}


### PR DESCRIPTION
Increase settings to disourage page widows and orphans.
Whether or not this has a visible affect depends on
the specifics of the text.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>