### PR TITLE
Show version date on front page

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -1,4 +1,5 @@
-% metamath.tex - Version of 17-Nov-2014
+% metamath.tex - Version of 30-Jan-2019
+% If you change the date above, also change the "Printed date" below.
 % SPDX-License-Identifier: CC0-1.0
 %
 %                              PUBLIC DOMAIN
@@ -769,8 +770,11 @@
 {\large Norman Megill} \\
 \vspace{7ex}
 with improvements by \\
+\vspace{1ex}
+{\large David A. Wheeler} \\
 \vspace{7ex}
-{\large David A. Wheeler}
+% Printed date. If changing the date below, also fix the date at the beginning.
+2019-01-30
 \end{center}
 
 \vfill


### PR DESCRIPTION
It's currently hard to figure out which version is being displayed.
Show a date on front cover to make it clear.

We won't bother to update the date on every revision in
version control, but we'll certainly make sure it's updated
on every release.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>