### PR TITLE
Add a new section on deduction

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -191,6 +191,12 @@
   biburl    = {https://dblp.org/rec/bib/journals/corr/Carneiro14},
   bibsource = {dblp computer science bibliography, https://dblp.org}
 }
+@article{CarneiroND,
+  author    = {Mario Carneiro},
+  title     = {Natural Deductions in the Metamath Proof Language},
+  url       = {http://us.metamath.org/ocat/natded.pdf},
+  year      = 2014
+}
 @inproceedings{Chou, author = "Shang-Ching Chou",
   title = "Proving Elementary Geometry Theorems Using {W}u's Algorithm",
   pages = "243--286",
@@ -308,6 +314,12 @@
   address = "New York",
   note = "[QA9.H63 1980]",
   year = 1979 }
+@article{Indrzejczak, author= "Andrzej Indrzejczak",
+  title = "Natural Deduction, Hybrid Systems and Modal Logic",
+  journal = "Trends in Logic",
+  volume = 30,
+  publisher = "Springer",
+  year = 2010 }
 @article{Kalish, author = "D. Kalish and R. Montague",
   title = "On {T}arski's Formalization of Predicate Logic with Identity",
   journal = "Archiv f{\"{u}}r Mathematische Logik und Grundlagenfor\-schung",
@@ -5120,7 +5132,7 @@ Axiom of Simplification.\label{ax1}
 \endm
 
 
-\noindent Rule of Modus Ponens.\index{modus ponens}
+\noindent Rule of Modus Ponens.\label{axmp}\index{modus ponens}
 
 \setbox\startprefix=\hbox{\tt \ \ maj\ \$e\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ }
@@ -6705,8 +6717,8 @@ should be read ``assume variable $x$ is
 
 In this section we list some of the more important theorems that are proved in
 the \texttt{set.mm} database, and they illustrate the kinds of things that can be
-done with Metamath.  While all of these facts are well-known results in set
-theory, Metamath offers the advantage of easily allowing you to trace their
+done with Metamath.  While all of these facts are well-known results,
+Metamath offers the advantage of easily allowing you to trace their
 derivation back to axioms.  Our intent here is not to try to explain the
 details or motivation; for this we refer you to the textbooks that are
 mentioned in the descriptions.  (The \texttt{set.mm} file has bibliographic
@@ -6717,7 +6729,41 @@ Section~\ref{hierarchy}.  For brevity we haven't included the \texttt{\$d}
 restrictions or \texttt{\$f} hypotheses for these theorems; when you are
 uncertain consult the \texttt{set.mm} database.
 
-Our first theorem is not very deep but provides us with a notational device
+We start with \texttt{syl} (principle of the syllogism).
+In \textit{Principia Mathematica}
+Whitehead and Russell call this ``the principle of the
+syllogism... because... the syllogism in Barbara is derived from them''
+\cite[quote after Theorem *2.06 p.~101]{PM}.
+Some authors call this law a ``hypothetical syllogism.''
+At the time of this writing it is the most commonly referenced assertion in the
+\texttt{set.mm} database.\footnote{
+The Metamath program command \texttt{show usage}
+shows the number of references.
+}
+
+\vskip 2ex
+\noindent Theorem syl (principle of the syllogism)\index{Syllogism}%
+\index{\texttt{syl}}\label{syl}.
+
+\vskip 0.5ex
+\setbox\startprefix=\hbox{\tt \ \ syl.1\ \$e\ }
+\setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
+\startm
+\m{\vdash}\m{(}\m{\varphi}\m{ \rightarrow }\m{\psi}\m{)}
+\endm
+\setbox\startprefix=\hbox{\tt \ \ syl.2\ \$e\ }
+\setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ }
+\startm
+\m{\vdash}\m{(}\m{\psi}\m{ \rightarrow }\m{\chi}\m{)}
+\endm
+\setbox\startprefix=\hbox{\tt \ \ syl\ \$p\ }
+\setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ }
+\startm
+\m{\vdash}\m{(}\m{\varphi}\m{ \rightarrow }\m{\chi}\m{)}
+\endm
+\vskip 2ex
+
+The following theorem is not very deep but provides us with a notational device
 that is frequently used.  It allows us to use the expression ``$A \in V$'' as
 a compact way of saying that class $A$ exists, i.e.\ is a set.
 
@@ -7446,6 +7492,312 @@ no exceptions.
 Each step is clear and can be immediately checked.
 In the HTML display you can even click on each reference to see why it is
 justified, making it easy to see why the proof works.
+
+\section{Deduction}\label{deduction}
+
+Strictly speaking,
+a deduction (also called an inference) is a kind of statement that needs
+some hypotheses to be true in order for its conclusion to be true.
+A theorem, on the other hand, has no hypotheses.
+Informally we often call both of them theorems, but in this section we
+will stick to the strict definitions.
+
+It sometimes happens that we have proved a deduction of the form
+$\varphi \Rightarrow \psi$
+(given hypothesis $\varphi$ we can prove $\psi$)
+and we want to then prove a theorem of the form
+$\varphi \rightarrow \psi$.
+
+Converting a deduction (which uses a hypothesis) into a theorem
+(which does not) is not as simple as you might think.
+The deduction says, ``if we can prove $\varphi$ then we can prove $\psi$,''
+which is in some sense weaker than saying
+``$\varphi$ implies $\psi$.''
+There is no axiom of logic that permits us to directly obtain the theorem
+given the deduction.\footnote{
+The conversion of a deduction to a theorem does not even hold in general
+for quantum propositional calculus,
+which is a weak subset of classical propositional calculus.
+It has been shown that adding the Standard Deduction Theorem (discussed below)
+to quantum propositional calculus turns it into classical
+propositional calculus!
+}
+
+This is in contrast to going the other way.
+If we have the theorem ($\varphi \rightarrow \psi$),
+it is easy to recover the deduction
+($\varphi \Rightarrow \psi$)
+using modus ponens\index{modus ponens}
+(\texttt{ax-mp}; see section \ref{axmp}).
+
+In the following subsections we discuss the standard deduction theorem
+(the traditional but awkward way to convert deductions into theorems),
+the weak deduction theorem (a limited version of the standard deduction
+theorem that is easier to use and was once widely used in
+\texttt{set.mm}\index{set theory database (\texttt{set.mm})}),
+and deduction style (the newer approach we now recommend in most cases).
+Deduction style prefixes each hypothesis (other than definitions) and the
+conclusion with a universal antecedent (``$\varphi \rightarrow$'').
+Deduction style is widely used in \texttt{set.mm},
+so it is useful to understand \textit{why} it is widely used.
+We will also briefly discuss our approach for using natural deduction
+within \texttt{set.mm}, as that approach is deeply related to deduction style.
+We conclude with a summary of the strengths of
+our approach, which we believe are compelling.
+
+\subsection{The Standard Deduction Theorem}
+
+It is possible to make use of information
+contained in the deduction or its proof to assist us with the proof of
+the related theorem.
+In traditional logic books, there is a metatheorem called the
+Deduction Theorem\index{Deduction Theorem}\index{Standard Deduction Theorem},
+discovered independently by Herbrand and Tarski around 1930.
+The Deduction Theorem, which we often call the Standard Deduction Theorem,
+provides an algorithm for constructing a proof of a theorem from the
+proof of its corresponding deduction. See, for example,
+\cite[p.~56]{Margaris}\index{Margaris, Angelo}.
+To construct a proof for a theorem, the
+algorithm looks at each step in the proof of the original deduction and
+rewrites the step with several steps wherein the hypothesis is eliminated
+and becomes an antecedent.
+
+In ordinary mathematics, no one actually carries out the algorithm,
+because (in its most basic form) it involves an exponential explosion of
+the number of proof steps as more hypotheses are eliminated. Instead,
+the Standard Deduction Theorem is invoked simply to claim that it can
+be done in principle, without actually doing it.
+What's more, the algorithm is not as simple as it might first appear
+when applying it rigorously.
+There is a subtle restriction on the Standard Deduction Theorem
+that must be taken into account involving the axiom of generalization
+when working with predicate calculus (see the literature for more detail).
+
+One of the goals of Metamath is to let you plainly see, with as few
+underlying concepts as possible, how mathematics can be derived directly
+from the axioms, and not indirectly according to some hidden rules
+buried inside a program or understood only by logicians. If we added
+the Standard Deduction Theorem to the language and proof verifier,
+that would greatly complicate both and largely defeat Metamath's goal
+of simplicity. In principle, we could show direct proofs by expanding
+out the proof steps generated by the algorithm of the Standard Deduction
+Theorem, but it is not feasible in practice because the number of proof
+steps quickly becomes huge, even astronomical. Since the algorithm is
+driven by proof of the deduction, we would have to go through that proof
+all over again—starting from axioms—in order to obtain the theorem
+form. In terms of proof length, there would be no savings over just
+proving the theorem directly instead of first proving the deduction form.
+
+\subsection{Weak Deduction Theorem}
+
+We have developed
+a more efficient method for proving a theorem from a deduction
+that can be used in many (but not all) cases.
+We call it the
+Weak Deduction Theorem\index{Weak Deduction Theorem}.\footnote{
+There is also an unrelated ``Weak Deduction Theorem''
+in the field of relevance logic, so to avoid confusion we could call
+ours the ``Weak Deduction Theorem for Classical Logic.''}
+Unlike the Standard Deduction Theorem, the Weak Deduction Theorem produces the
+theorem directly from a special substitution instance of the deduction,
+using a small, fixed number of steps roughly proportional to the length
+of the final theorem.
+You can see its details in theorem \texttt{dedth}.
+
+The weak deduction theorem has limitations.
+Specifically, we must be able to prove a special case of the deduction's
+hypothesis as a stand-alone theorem.
+
+We used to use the weak deduction theorem
+extensively within \texttt{set.mm}.
+However, we now recommend applying something called ``deduction style''
+instead in most cases, as deduction style is
+often an easier and clearer approach.
+
+\subsection{Deduction style}
+
+Today there is a preference for writing assertions in
+something called``deduction form''
+instead of writing a proof that would require use of the standard or
+weak deduction theorem. Applying this approach is called
+``deduction style.''\index{deduction style}
+
+An assertion is in deduction form\index{deduction form}%
+\index{forms!deduction}
+if the conclusion is an implication with
+a wff variable as the antecedent (usually $\varphi$), and every MPE hypothesis
+(\$e statement) is either a definition or is also an implication with
+the same wff variable as the antecedent (usually $\varphi$). A definition
+can be for a class variable (this is a class variable followed by ``='')
+or a wff variable (this is a wff variable followed by $\leftrightarrow$);
+in practice
+definitions (if used) are for class variables. In practice, a proof
+in deduction form will also contain many steps that are implications
+where the antecedent is either that wff variable (normally $\varphi$)
+or is
+a conjunction (...$\land$...) including that wff variable ($\varphi$).
+
+By contrast, we call assertions with hypotheses
+but no common antecedent ``inference form''\index{inference form}%
+\index{forms!inference}
+and suffix its label with ``i.''
+A theorem in ``closed form''\index{closed form}%
+\index{forms!closed}
+is a theorem with no hypotheses,
+and its label would have no suffix.
+If an assertion is in deduction form, and other forms are also available,
+then we suffix its label with ``d.''
+
+In deduction form the antecedent (e.g., $\varphi$) mimics the context handled
+in the deduction theorem.
+Once you have an assertion in deduction form, you can easily convert it
+to inference form or closed form:
+
+\begin{itemize}
+\item To
+prove some assertion Ti in inference form, given assertion Td in deduction
+form, there is a simple mechanical process you can use. First take each
+Ti hypothesis and insert a \texttt{T.} $\rightarrow$ prefix (``true implies'')
+using \texttt{a1i}. You
+can then use the existing assertion Td to prove the resulting conclusion
+with a \texttt{T.} $\rightarrow$ prefix.
+Finally, you can remove that prefix using \texttt{trud},
+resulting in the conclusion you wanted to prove.
+\item To
+prove some assertion T in closed form, given assertion Td in deduction
+form, there is another simple mechanical process you can use. First,
+select an expression that is the conjunction (...$\land$...) of all of the
+consequents of every hypothesis of Td. Next, prove that this expression
+implies each of the separate hypotheses of Td in turn by eliminating
+conjuncts (there are a variety of proven assertions to do this, including
+\texttt{simpl},
+\texttt{simpr},
+\texttt{3simpa},
+\texttt{3simpb},
+\texttt{3simpc},
+\texttt{simp1},
+\texttt{simp2},
+and
+\texttt{simp3}).
+If the
+expression has nested conjunctions, inner conjuncts can be broken out by
+chaining the above theorems with \texttt{syl}
+(see section \ref{syl}).\footnote{
+There are actually many theorems
+(labeled simp* such as \texttt{simp333}) that break out inner conjuncts in one
+step, but rather than learning them you can just use the chaining we
+just described to prove them, and then let the Metamath program command
+\texttt{minimize{\char`\_}with}\index{\texttt{minimize{\char`\_}with} command}
+figure out the right ones needed to collapse them.}
+As your final step, you can then apply the already-proven assertion Td
+(which is in deduction form), proving assertion T in closed form.
+\end{itemize}
+
+We can also easily convert any assertion T in closed form to its related
+assertion Ti in inference form by applying
+modus ponens\index{modus ponens} (see section \ref{axmp}).
+
+The deduction form antecedent can also be used to represent the context
+necessary to support natural deduction systems, so we now
+turn to discuss natural deduction.
+
+\subsection{Natural Deduction}
+
+Natural deduction\index{natural deduction}
+(ND) systems, as such, were originally introduced in
+1934 by two logicians working independently: Jaśkowski and Gentzen. ND
+systems are supposed to reconstruct, in a formally proper way, traditional
+ways of mathematical reasoning (such as conditional proof, indirect proof,
+and proof by cases). As reconstructions they were naturally influenced
+by previous work, and many specific ND systems and notations have been
+developed since their original work.
+
+There are many ND variants, but
+Indrzejczak\cite[p.~31-32]{Indrzejczak}\index{Indrzejczak, Andrzej}
+suggests that any natural deductive system must satisfy at
+least these three criteria:
+
+\begin{itemize}
+\item ``There are some means for entering assumptions into a proof and
+also for eliminating them. Usually it requires some bookkeeping devices
+for indicating the scope of an assumption, and showing that a part of
+a proof depending on eliminated assumption is discharged.
+\item There are no (or, at least, very limited set of) axioms, because
+their role is taken over by the set of primitive rules for introduction
+and elimination of logical constants which means that elementary
+inferences instead of formulae are taken as primitive.
+\item (A genuine) ND system admits a lot of freedom in proof construction
+and possibility of applying several proof search strategies, like
+conditional proof, proof by cases, proof by reductio ad absurdum etc.''
+\end{itemize}
+
+The Metamath Proof Explorer (MPE) as defined in \texttt{set.mm}
+is fundamentally a Hilbert-style system.
+That is, MPE is based on a larger number of axioms (compared
+to natural deduction systems), a very small set of rules of inference
+(modus ponens), and the context is not changed by the rules of inference
+in the middle of a proof. That said, MPE proofs can be developed using
+the natural deduction (ND) approach as originally developed by Jaśkowski
+and Gentzen.
+
+The most common and recommended approach for applying ND in MPE is to use
+deduction form\index{deduction form}%
+\index{forms!deduction}
+and apply the MPE proven assertions that are equivalent to ND rules.
+For example, MPE's \texttt{jca} is equivalent to ND rule $\land$-I
+(and-insertion).
+We maintain a list of equivalences that you may consult.
+This approach for applying an ND approach within MPE relies on Metamath's
+wff metavariables in an essential way, and is described in more detail
+in the presentation ``Natural Deductions in the Metamath Proof Language''
+by Mario Carneiro\cite{CarneiroND}\index{Carneiro, Mario}.
+
+In this style many steps are an implication, whose antecedent mimics
+the context ($\Gamma$) of most ND systems. To add an assumption, simply add
+it to the implication antecedent (typically using
+\texttt{simpr}),
+and use that
+new antecedent for all later claims in the same scope. If you wish to
+use an assertion in an ND hypothesis scope that is outside the current
+ND hypothesis scope, modify the assertion so that the ND hypothesis
+assumption is added to its antecedent (typically using \texttt{adantr}). Most
+proof steps will be proved using rules that have hypotheses and results
+of the form $\varphi \rightarrow$ ...
+
+\subsection{Strengths of Our Approach}
+
+As far as we know there is nothing else in the literature like either the
+weak deduction theorem or Mario Carneiro\index{Carneiro, Mario}'s
+natural deduction method.
+In order to
+transform a hypothesis into an antecedent, the literature's standard
+``Deduction Theorem''\index{Deduction Theorem}\index{Standard Deduction Theorem}
+requires metalogic outside of the notions provided
+by the axiom system. We instead generally prefer to use Mario Carneiro's
+natural deduction method, then use the weak deduction theorem in cases
+where that is difficult to apply, and only then use the full standard
+deduction theorem as a last resort.
+
+The weak deduction theorem\index{Weak Deduction Theorem}
+does not require any additional metalogic
+but converts an inference directly into a closed form theorem, with
+a rigorous proof that uses only the axiom system. Unlike the standard
+Deduction Theorem, there is no implicit external justification that we
+have to trust in order to use it.
+
+Mario's natural deduction\index{natural deduction}
+method also does not require any new metalogical
+notions. It avoids the Deduction Theorem's metalogic by prefixing the
+hypotheses and conclusion of every would-be inference with a universal
+antecedent (``$\varphi \rightarrow$'') from the very start.
+
+We think it is impressive and satisfying that we can do so much in a
+practical sense without stepping outside of our Hilbert-style axiom system.
+Of course our axiomatization, which is in the form of schemes,
+contains a metalogic of its own that we exploit. But this metalogic
+is relatively simple, and for our Deduction Theorem alternatives,
+we primarily use just the direct substitution of expressions for
+metavariables.
 
 \section{Exploring the Set Theory Database}\label{exploring}
 


### PR DESCRIPTION
This adds a new section on deduction, including a discussion of the
standard deduction theorem, the weak deduction theorem,
deduction form, and natural deduction.

It also adds "syl" to the list of theorems, because we refer to it.
Syl is the most commonly-used theorem, so we should mention it anyway.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>