### PR TITLE
Credit Mario with the most Metamath 100 proofs

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -2863,11 +2863,17 @@ The Metamath 100%
 \footnote{\url{http://us.metamath.org/mm\_100.html}}
 page (maintained by David A. Wheeler\index{Wheeler, David A.})
 shows the progress of Metamath (specifically its \texttt{set.mm} database)
-against this challenge list  maintained by Freek Wiedijk.
+against this challenge list maintained by Freek Wiedijk.
 The Metamath \texttt{set.mm} database
 has made a lot of progress over the years,
 in part because working to prove those challenge theorems required
 defining various terms and proving their properties as a prerequisite.
+We thank all of those who developed at least one of the Metamath 100
+proofs, and we particularly thank
+Mario Carneiro\index{Carneiro, Mario}
+who has contributed the most Metamath 100 proofs as of 2019.
+The Metamath 100 page shows the list of all people who have contributed a
+proof, and links to graphs and charts showing progress over time.
 We encourage others to work on proving theorems not yet proven in Metamath,
 since doing so improves the work as a whole.
 


### PR DESCRIPTION
Credit Mario with the most Metamath 100 proofs, for two reasons:
(1) He's earned it! (2) It might encourage other people
to work on such proofs.  This also points out where
you can see the names of all contributors.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>