### PR TITLE
Improve page breaks, fixes #80

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -13752,8 +13752,10 @@ and would have allowed us to prove nonsense.  Note that there is no
 concept of operator binding precedence built into our formal system.
 \end{quotation}}
 
+\begin{sloppy}
 \subsection{Example~2---Predicate Calculus with Equality}\index{predicate
 calculus}
+\end{sloppy}
 
 Here we extend Example~1 to include predicate calculus with equality,
 illustrating the use of distinct-variable restrictions.  This system is the
@@ -14010,9 +14012,11 @@ metatheorems are (directly) provable statements. The precise definition of
 Example~3 is found in Remark 9.6 and Theorem 9.7 of \cite{Megill}.\index{Megill,
 Norman}
 
+\begin{sloppy}
 \subsection{Example~3---Metalogically Complete Predicate
 Calculus with
 Equality}
+\end{sloppy}
 
 For simplicity we will assume there is one binary predicate $R$;
 this system suffices for set theory, where the $R$ is of course the $\in$

--- a/metamath.tex
+++ b/metamath.tex
@@ -7831,7 +7831,9 @@ is relatively simple, and for our Deduction Theorem alternatives,
 we primarily use just the direct substitution of expressions for
 metavariables.
 
-\section{Exploring the Set Theory Database}\label{exploring}
+\begin{sloppy}
+\section{Exploring the Set The\-o\-ry Data\-base}\label{exploring}
+\end{sloppy}
 
 At this point you may wish to study the \texttt{set.mm}\index{set theory
 database (\texttt{set.mm})} file in more detail.  Pay particular
@@ -10472,11 +10474,13 @@ placed in the \LaTeX\ output file.
 labels for correct output of {\sc html}, described in the next section,
 and error messages will be issued during that output if they aren't.)
 
-\subsection{Comment Markup Notation for HTML}\label{htmlmkup}
+\begin{sloppy}
+\subsection{Comment Markup No\-ta\-tion for HTML}\label{htmlmkup}
 \index{\texttt{`} inside comments}
 \index{\texttt{\char`\~} inside comments}
 \index{markup notation}
 \index{comments!markup notation}
+\end{sloppy}
 
 The automated generation of {\sc html}\index{html generation@{\sc html}
 generation} web pages
@@ -10825,8 +10829,9 @@ assigned to \texttt{exthtmltitle} and \texttt{exthtmlhome} is used
 instead of that assigned to \texttt{htmltitle} and \texttt{htmlhome},
 respectively.
 
-
-\subsection{Additional Information Comment (\texttt{\$j})} \label{jcomment}
+\begin{sloppy}
+\subsection{Additional Information Com\-ment (\texttt{\$j})} \label{jcomment}
+\end{sloppy}
 
 The additional information comment, aka the
 \texttt{\$j}\index{\texttt{\$j} comment}\index{additional information comment}

--- a/metamath.tex
+++ b/metamath.tex
@@ -721,6 +721,8 @@
 \documentclass[leqno]{book} % LaTeX 2e. 10pt. Use [leqno,12pt] for 12pt
 % hyperref 2002/05/27 v6.72r  (couldn't get pagebackref to work)
 \usepackage[plainpages=false,pdfpagelabels=true]{hyperref}
+
+\usepackage{needspace}     % Enable control over page breaks
 \usepackage{breqn}         % automatic equation breaking
 \usepackage{microtype}     % microtypography, reduces hyphenation
 
@@ -5106,6 +5108,7 @@ typeset them.
   \box\mlinebox
 }
 
+\needspace{4\baselineskip}
 \subsection{Propositional Calculus}\label{propcalc}\index{axioms of
 propositional calculus}
 
@@ -5138,6 +5141,7 @@ Axiom of Simplification.\label{ax1}
 \endm
 
 
+\needspace{5\baselineskip}
 \noindent Rule of Modus Ponens.\label{axmp}\index{modus ponens}
 
 \setbox\startprefix=\hbox{\tt \ \ maj\ \$e\ }
@@ -5159,6 +5163,7 @@ Axiom of Simplification.\label{ax1}
 \endm
 
 
+\needspace{7\baselineskip}
 \subsection{Axioms of Predicate Calculus with equality - Tarski's S2}\index{axioms of predicate calculus}
 
 \noindent Rule of Generalization.\index{rule of generalization}
@@ -5175,6 +5180,7 @@ Axiom of Simplification.\label{ax1}
 \m{\vdash}\m{\forall}\m{x}\m{\varphi}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Quantified Implication.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-4\ \$a\ }
@@ -5185,6 +5191,7 @@ Axiom of Simplification.\label{ax1}
 \forall}\m{x}\m{\psi}\m{)}\m{)}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Distinctness.
 
 % Aka: Add $d x ph $.

--- a/metamath.tex
+++ b/metamath.tex
@@ -5112,6 +5112,7 @@ typeset them.
 \subsection{Propositional Calculus}\label{propcalc}\index{axioms of
 propositional calculus}
 
+\needspace{2\baselineskip}
 Axiom of Simplification.\label{ax1}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-1\ \$a\ }
@@ -5121,6 +5122,7 @@ Axiom of Simplification.\label{ax1}
 \m{)}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Distribution.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-2\ \$a\ }
@@ -5131,6 +5133,7 @@ Axiom of Simplification.\label{ax1}
 \rightarrow}\m{(}\m{\varphi}\m{\rightarrow}\m{\chi}\m{)}\m{)}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Contraposition.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-3\ \$a\ }
@@ -5141,7 +5144,7 @@ Axiom of Simplification.\label{ax1}
 \endm
 
 
-\needspace{5\baselineskip}
+\needspace{4\baselineskip}
 \noindent Rule of Modus Ponens.\label{axmp}\index{modus ponens}
 
 \setbox\startprefix=\hbox{\tt \ \ maj\ \$e\ }
@@ -5166,6 +5169,7 @@ Axiom of Simplification.\label{ax1}
 \needspace{7\baselineskip}
 \subsection{Axioms of Predicate Calculus with equality - Tarski's S2}\index{axioms of predicate calculus}
 
+\needspace{3\baselineskip}
 \noindent Rule of Generalization.\index{rule of generalization}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-g.1\ \$e\ }
@@ -5180,7 +5184,7 @@ Axiom of Simplification.\label{ax1}
 \m{\vdash}\m{\forall}\m{x}\m{\varphi}
 \endm
 
-\needspace{3\baselineskip}
+\needspace{2\baselineskip}
 \noindent Axiom of Quantified Implication.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-4\ \$a\ }
@@ -5201,6 +5205,7 @@ Axiom of Simplification.\label{ax1}
 \m{\vdash}\m{(}\m{\varphi}\m{\rightarrow}\m{\forall}\m{x}\m{\varphi}\m{)}\m{where}\m{ }\m{\$d}\m{ }\m{x}\m{ }\m{\varphi}\m{ }\m{(}\m{x}\m{ }\m{does}\m{ }\m{not}\m{ }\m{occur}\m{ }\m{in}\m{ }\m{\varphi}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Existence.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-6\ \$a\ }
@@ -5210,6 +5215,7 @@ Axiom of Simplification.\label{ax1}
 \m{x}\m{\varphi}\m{)}\m{\rightarrow}\m{\varphi}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Equality.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-7\ \$a\ }
@@ -5219,6 +5225,7 @@ Axiom of Simplification.\label{ax1}
 \rightarrow}\m{y}\m{=}\m{z}\m{)}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Left Equality for Binary Predicate.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-8\ \$a\ }
@@ -5228,6 +5235,7 @@ Axiom of Simplification.\label{ax1}
 \rightarrow}\m{y}\m{\in}\m{z}\m{)}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Right Equality for Binary Predicate.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-9\ \$a\ }
@@ -5238,8 +5246,10 @@ Axiom of Simplification.\label{ax1}
 \endm
 
 
+\needspace{4\baselineskip}
 \subsection{Axioms of Predicate Calculus with Equality - Auxiliary}\index{axioms of predicate calculus - auxiliary}
 
+\needspace{2\baselineskip}
 \noindent Axiom of Quantified Negation.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-10\ \$a\ }
@@ -5249,6 +5259,7 @@ Axiom of Simplification.\label{ax1}
 \rightarrow}\m{\varphi}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Quantifier Commutation.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-11\ \$a\ }
@@ -5258,7 +5269,7 @@ Axiom of Simplification.\label{ax1}
 \forall}\m{y}\m{\forall}\m{x}\m{\varphi}\m{)}
 \endm
 
-
+\needspace{3\baselineskip}
 \noindent Axiom of Substitution.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-12\ \$a\ }
@@ -5269,6 +5280,7 @@ Axiom of Simplification.\label{ax1}
 \m{x}\m{=}\m{y}\m{\rightarrow}\m{\varphi}\m{)}\m{)}\m{)}\m{)}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Quantified Equality.
 
 \setbox\startprefix=\hbox{\tt \ \ ax-13\ \$a\ }
@@ -5353,6 +5365,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
   \texttt{\$d }$x\,y\,z\,w$
 \end{center}
 
+\needspace{2\baselineskip}
 \noindent Axiom of Extensionality.\index{Axiom of Extensionality}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-ext\ \$a\ }
@@ -5362,6 +5375,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
 \m{\in}\m{z}\m{)}\m{\rightarrow}\m{y}\m{=}\m{z}\m{)}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Replacement.\index{Axiom of Replacement}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-rep\ \$a\ }
@@ -5374,6 +5388,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
 \m{)}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Union.\index{Axiom of Union}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-un\ \$a\ }
@@ -5383,6 +5398,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
 \in}\m{x}\m{\wedge}\m{x}\m{\in}\m{z}\m{)}\m{\rightarrow}\m{y}\m{\in}\m{x}\m{)}
 \endm
 
+\needspace{2\baselineskip}
 \noindent Axiom of Power Sets.\index{Axiom of Power Sets}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-pow\ \$a\ }
@@ -5393,6 +5409,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
 \m{)}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Regularity.\index{Axiom of Regularity}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-reg\ \$a\ }
@@ -5403,6 +5420,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
 \rightarrow}\m{\lnot}\m{z}\m{\in}\m{y}\m{)}\m{)}\m{)}
 \endm
 
+\needspace{3\baselineskip}
 \noindent Axiom of Infinity.\index{Axiom of Infinity}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-inf\ \$a\ }
@@ -5413,6 +5431,7 @@ p.~\pageref{nodd}.}\index{\texttt{\$d} statement} thus we also assume:
 \wedge}\m{z}\m{\in}\m{x}\m{)}\m{)}\m{)}
 \endm
 
+\needspace{4\baselineskip}
 \noindent Axiom of Choice.\index{Axiom of Choice}
 
 \setbox\startprefix=\hbox{\tt \ \ ax-ac\ \$a\ }


### PR DESCRIPTION
Use \needspace to improve page breaks.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>