### PR TITLE
Make single quotes straight in wide version verbatim

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -728,6 +728,7 @@
 % hyperref 2002/05/27 v6.72r  (couldn't get pagebackref to work)
 \usepackage[plainpages=false,pdfpagelabels=true]{hyperref}
 
+\usepackage{upquote}       % Use straight quotes in verbatim environments
 \usepackage{needspace}     % Enable control over page breaks
 \usepackage{breqn}         % automatic equation breaking
 \usepackage{microtype}     % microtypography, reduces hyphenation

--- a/narrow.sty
+++ b/narrow.sty
@@ -1,6 +1,10 @@
 % Settings to generate PDF for a narrow display (e.g. a smartphone).
 % Copy this file to special-settings.sty to use it.
 
+% TODO: Ideally listings should show single quotes as straight
+% (not curly). HOwever We can't set upquote=true because we can't be
+% sure we have the font.  So we document where it WOULD go below.
+
 \usepackage[papersize={3.6in,4.8in},hmargin=0.1in,vmargin={0.1in,0.1in}]{geometry}  % page geometry
 
 % Use "listings" package.  This lets us have automatic line breaking.
@@ -11,6 +15,7 @@
   basicstyle=\ttfamily\footnotesize,      % print size
   breaklines=true,                        % sets automatic line breaking
   breakatwhitespace=true,                 % sets if automatic breaks should only happen at whitespace
+  % upquote=true, % Make single quotes upright.
 }
 
 % Override definition of "verbatim" with a "listings" block.


### PR DESCRIPTION
In the wide (normal) width, display single quotes as
straight inside the verbatim environments.
Ideally we'd do that in the narrow case too, but we
can't be sure we have the right fonts.  So document
what WOULD do it, if we had the fonts, and let it be.

This at gives us straight single quotes in the
"normal" (wide) case, and I think that's an improvement.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>