### PR TITLE
Fix narrow generation font problem

### DIFF
--- a/generate-pdf
+++ b/generate-pdf
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Generate metamath.pdf from source file metamath.tex.
 
+# $1 = special-settings file to copy from, wide.sty by default
+
+# WARNING: We manipulate the "special-setting.sty" file, so don't
+# run this in parallel.
+
 # Stop processing if error occurs (-e) and show what we're doing (-x)
 set -ex
 
@@ -9,6 +14,9 @@ set -ex
 do_pdflatex () {
   pdflatex -halt-on-error -interaction=nonstopmode "$1"
 }
+
+style_special="${1:-wide.sty}"
+cp -p "$style_special" special-settings.sty
 
 # Try to remove metamath.pdf first - if we can't, no point in going further.
 rm -f metamath.pdf
@@ -23,6 +31,10 @@ bibtex metamath
 makeindex metamath
 do_pdflatex metamath
 do_pdflatex metamath
+
+# Clean up temporary "special-settings.sty" file
+rm -f special-settings.sty
+touch special-settings.sty
 
 # Print errors not already allowed; return error code if there are any
 if ! grep -Ei '(Error|Warning):' metamath.log | grep -vF -f allowed-errors

--- a/generate-pdf
+++ b/generate-pdf
@@ -18,8 +18,6 @@ do_pdflatex () {
 style_special="${1:-wide.sty}"
 cp -p "$style_special" special-settings.sty
 
-bash
-
 # Try to remove metamath.pdf first - if we can't, no point in going further.
 rm -f metamath.pdf
 

--- a/generate-pdf
+++ b/generate-pdf
@@ -18,6 +18,8 @@ do_pdflatex () {
 style_special="${1:-wide.sty}"
 cp -p "$style_special" special-settings.sty
 
+bash
+
 # Try to remove metamath.pdf first - if we can't, no point in going further.
 rm -f metamath.pdf
 

--- a/make-narrow
+++ b/make-narrow
@@ -2,10 +2,4 @@
 # Make metamath-narrow.pdf
 # WARNING: This erases metamath.pdf and special-settings.sty
 
-cp -p narrow.sty special-settings.sty
-
-./generate-pdf
-mv metamath.pdf metamath-narrow.pdf
-
-rm -f special-settings.sty
-touch special-settings.sty
+./generate-pdf narrow.sty && mv metamath.pdf metamath-narrow.pdf

--- a/metamath.tex
+++ b/metamath.tex
@@ -737,7 +737,6 @@
 % hyperref 2002/05/27 v6.72r  (couldn't get pagebackref to work)
 \usepackage[plainpages=false,pdfpagelabels=true]{hyperref}
 
-\usepackage{upquote}       % Use straight quotes in verbatim environments
 \usepackage{needspace}     % Enable control over page breaks
 \usepackage{breqn}         % automatic equation breaking
 \usepackage{microtype}     % microtypography, reduces hyphenation

--- a/metamath.tex
+++ b/metamath.tex
@@ -801,18 +801,6 @@
 % \usepackage[papersize={3.6in,4.8in},hmargin=0.1in,vmargin={0.1in,0.1in}]{geometry}  % page geometry
 \usepackage{special-settings}
 
-
-% DEBUG: This is a TEMPORARY debug hack from:
-% https://tex.stackexchange.com/questions/154594/how-to-diagnose-a-permanent-labels-may-have-changed-warning
-% Hopefully it will help debug problems we've had
-\def\@testdef #1#2#3{%
-  \def\reserved@a{#3}\expandafter \ifx \csname #1@#2\endcsname
- \reserved@a  \else
-\typeout{^^Jlabel #2 changed:^^J%
-\meaning\reserved@a^^J%
-\expandafter\meaning\csname #1@#2\endcsname^^J}%
-\@tempswatrue \fi}
-
 \raggedbottom
 \makeindex
 

--- a/metamath.tex
+++ b/metamath.tex
@@ -801,6 +801,18 @@
 % \usepackage[papersize={3.6in,4.8in},hmargin=0.1in,vmargin={0.1in,0.1in}]{geometry}  % page geometry
 \usepackage{special-settings}
 
+
+% DEBUG: This is a TEMPORARY debug hack from:
+% https://tex.stackexchange.com/questions/154594/how-to-diagnose-a-permanent-labels-may-have-changed-warning
+% Hopefully it will help debug problems we've had
+\def\@testdef #1#2#3{%
+  \def\reserved@a{#3}\expandafter \ifx \csname #1@#2\endcsname
+ \reserved@a  \else
+\typeout{^^Jlabel #2 changed:^^J%
+\meaning\reserved@a^^J%
+\expandafter\meaning\csname #1@#2\endcsname^^J}%
+\@tempswatrue \fi}
+
 \raggedbottom
 \makeindex
 

--- a/wide.sty
+++ b/wide.sty
@@ -1,0 +1,5 @@
+% These are formatting commands only used in "wide" (normal)
+
+% This can only be in "wide" - when we do this in "narrow" we
+% end up requiring fonts that we don't necessarily have.
+\usepackage{upquote}       % Use straight quotes in verbatim environments


### PR DESCRIPTION
The previous changes accidentally required
fonts that may not be available when generating
the narrow form.

This commit modifies the generation process so that
we *always* use a special style file, either "wide.sty"
(normal case) or "narrow.sty" (narrow case).
That way we can *force* the system so that we
*only* run \usepackage{upquote} in wide mode
(this causes straight quotes in verbatim environments).
The problem is that trying to do this in narrow mode
requires fonts we may not have.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>