### PR TITLE
Revert "Make single quotes straight in wide version verbatim"

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -737,7 +737,6 @@
 % hyperref 2002/05/27 v6.72r  (couldn't get pagebackref to work)
 \usepackage[plainpages=false,pdfpagelabels=true]{hyperref}
 
-\usepackage{upquote}       % Use straight quotes in verbatim environments
 \usepackage{needspace}     % Enable control over page breaks
 \usepackage{breqn}         % automatic equation breaking
 \usepackage{microtype}     % microtypography, reduces hyphenation

--- a/narrow.sty
+++ b/narrow.sty
@@ -1,10 +1,6 @@
 % Settings to generate PDF for a narrow display (e.g. a smartphone).
 % Copy this file to special-settings.sty to use it.
 
-% TODO: Ideally listings should show single quotes as straight
-% (not curly). HOwever We can't set upquote=true because we can't be
-% sure we have the font.  So we document where it WOULD go below.
-
 \usepackage[papersize={3.6in,4.8in},hmargin=0.1in,vmargin={0.1in,0.1in}]{geometry}  % page geometry
 
 % Use "listings" package.  This lets us have automatic line breaking.
@@ -15,7 +11,6 @@
   basicstyle=\ttfamily\footnotesize,      % print size
   breaklines=true,                        % sets automatic line breaking
   breakatwhitespace=true,                 % sets if automatic breaks should only happen at whitespace
-  % upquote=true, % Make single quotes upright.
 }
 
 % Override definition of "verbatim" with a "listings" block.


### PR DESCRIPTION
This reverts commit 9a19c2f88b530748a9f0c98410e1bac1ca0012af.

I can't get this to work reliably on my local system
due to font problems, and fancier approaches don't seem to
work either.  The simplest solution is to revert the whole thing,
at least for now.