### PR TITLE
EBNF tweak for filename

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -14876,7 +14876,7 @@ compressed-proof ::= '(' LABEL* ')' COMPRESSED-PROOF-BLOCK+
 
 typecode ::= constant
 
-filename ::= PRINTABLE-SEQUENCE
+filename ::= MATH-SYMBOL /* Cannot include whitespace or '$' */
 constant ::= MATH-SYMBOL
 variable ::= MATH-SYMBOL
 \end{verbatim}


### PR DESCRIPTION
Filenames can't include '$', so they aren't really a
PRINTABLE-SEQUENCE.  It turns out they are exactly a
MATH-SYMBOL (which cannot include whitespace or '$')...
so say so in the EBNF.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>