### PR TITLE
Fix misleading appendix comment on substitution

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -13378,7 +13378,11 @@ if that is necessary for clarity.
   \hyperref[df-sb]{\texttt{df-sb}} &
   The wff $[ y / x ] \varphi$ produces
   the result when $y$ is properly substituted for $x$ in $\varphi$
-  ($y$ replaces $x$). \\
+  ($y$ replaces $x$).
+  % This is elsb4
+  % ( [ x / y ] z e. y <-> z e. x )
+  For example,
+  $[ x / y ] z \in y$ is the same as $z \in x$. \\
 \texttt{E!} & $\exists !$ &
   \hyperref[df-eu]{\texttt{df-eu}} &
   There exists exactly one;

--- a/metamath.tex
+++ b/metamath.tex
@@ -13377,8 +13377,8 @@ if that is necessary for clarity.
 \texttt{[ y / x ]} & $[ y / x ]$ &
   \hyperref[df-sb]{\texttt{df-sb}} &
   The wff $[ y / x ] \varphi$ produces
-  the result when $y$ is properly substituted with its replacement $x$
-  in $\varphi$. \\
+  the result when $y$ is properly substituted for $x$ in $\varphi$
+  ($y$ replaces $x$). E.g., $[ y / x ] x = y$. \\
 \texttt{E!} & $\exists !$ &
   \hyperref[df-eu]{\texttt{df-eu}} &
   There exists exactly one;

--- a/metamath.tex
+++ b/metamath.tex
@@ -13378,7 +13378,7 @@ if that is necessary for clarity.
   \hyperref[df-sb]{\texttt{df-sb}} &
   The wff $[ y / x ] \varphi$ produces
   the result when $y$ is properly substituted for $x$ in $\varphi$
-  ($y$ replaces $x$). E.g., $[ y / x ] x = y$. \\
+  ($y$ replaces $x$). \\
 \texttt{E!} & $\exists !$ &
   \hyperref[df-eu]{\texttt{df-eu}} &
   There exists exactly one;


### PR DESCRIPTION
In the appendix listing sample symbols,
the explanation about substitution was misleading
(it seemed backwards).  Make the order abundantly clear,
e.g., expressly note that [ y / x ] x = y.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>