### PR TITLE
Improve discussion of df-sb

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -5841,9 +5841,9 @@ substitution}\index{substitution!proper}\label{df-sb}
 For our notation, we use $[ y / x ] \varphi$ to mean ``the wff that
 results when $y$ is properly substituted for $x$ in the wff $\varphi$''
 (that is, $y$ properly replaces $x$).
-% This is elsb4 : ( [ x / y ] z e. y <-> z e. x )
+% This is elsb4, though it currently says: ( [ x / y ] z e. y <-> z e. x )
 For example,
-$[ x / y ] z \in y$ is the same as $z \in x$.
+$[ y / x ] z \in x$ is the same as $z \in y$.
 The notation is different from the notation $\varphi ( x | y )$
 that is sometimes used, because the latter notation is ambiguous for us:
 for example, we don't know whether $\lnot \varphi ( x | y )$ is to be

--- a/metamath.tex
+++ b/metamath.tex
@@ -5838,15 +5838,13 @@ mentioned.
 
 \noindent Define proper substitution.\index{proper
 substitution}\index{substitution!proper}\label{df-sb}
-Note that this
-definition is valid even when
-$x$ and $y$ are the same variable.  The first conjunct is a ``trick'' used to
-achieve this property, making the definition look somewhat peculiar at
-first.   For our notation, we use $[ y / x ] \varphi$ to mean ``the wff that
-results when $y$ is properly substituted with $x$ in the wff $\varphi$.''  The
-notation is different from the notation $\varphi (
-x | y )$ that is sometimes used, because the latter notation is ambiguous
-for us:
+For our notation, we use $[ y / x ] \varphi$ to mean ``the wff that
+results when $y$ is properly substituted with $x$ in the wff $\varphi$.''
+% This is elsb4 : ( [ x / y ] z e. y <-> z e. x )
+For example,
+$[ x / y ] z \in y$ is the same as $z \in x$.
+The notation is different from the notation $\varphi ( x | y )$
+that is sometimes used, because the latter notation is ambiguous for us:
 for example, we don't know whether $\lnot \varphi ( x | y )$ is to be
 interpreted as $\lnot ( \varphi x | y )$ or $( \lnot \varphi x | y
 )$.\footnote{Because of the way we initially defined wffs, this is the case
@@ -5863,6 +5861,11 @@ could actually redefine all notation to be Polish if we wanted to without
 having to change any proofs!}  Other texts often use $\varphi(y)$ to indicate
 our $[ y / x ] \varphi$, but this notation is even more ambiguous since there is
 no explicit indication of what is being substituted.
+Note that this
+definition is valid even when
+$x$ and $y$ are the same variable.  The first conjunct is a ``trick'' used to
+achieve this property, making the definition look somewhat peculiar at
+first.
 
 \vskip 0.5ex
 \setbox\startprefix=\hbox{\tt \ \ df-sb\ \$a\ }

--- a/metamath.tex
+++ b/metamath.tex
@@ -5839,7 +5839,8 @@ mentioned.
 \noindent Define proper substitution.\index{proper
 substitution}\index{substitution!proper}\label{df-sb}
 For our notation, we use $[ y / x ] \varphi$ to mean ``the wff that
-results when $y$ is properly substituted with $x$ in the wff $\varphi$.''
+results when $y$ is properly substituted for $x$ in the wff $\varphi$''
+(that is, $y$ properly replaces $x$).
 % This is elsb4 : ( [ x / y ] z e. y <-> z e. x )
 For example,
 $[ x / y ] z \in y$ is the same as $z \in x$.


### PR DESCRIPTION
Add an explicit example to make clear what is being substituted for what.
Also, reorder the explanation to make it clearer.
Basically, describe what substitution does *first*, then why we
use that notation as opposed to some others, and only *then*
discuss a technical trick that the definition uses.
A reader will have a harder time understanding the technical trick if he
doesn't first understand what the definition is trying to accomplish.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>