### PR TITLE
Add Middle initial of van der Vekens (fxies #136)

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -1,4 +1,4 @@
-% metamath.tex - Version of 7-Apr-2019
+% metamath.tex - Version of 20-May-2019
 % If you change the date above, also change the "Printed date" below.
 % SPDX-License-Identifier: CC0-1.0
 %
@@ -840,7 +840,7 @@ with improvements by \\
 {\large David A. Wheeler} \\
 \vspace{7ex}
 % Printed date. If changing the date below, also fix the date at the beginning.
-2019-04-07
+2019-05-20
 \end{center}
 
 \vfill
@@ -1391,6 +1391,11 @@ from \texttt{set} to \texttt{setvar} to be consistent with the current
 version of \texttt{set.mm}, added more documentation about comment markup
 (e.g., documented how to create headings), and clarified the
 differences between various assertion forms (in particular deduction form).
+
+\subsubsection{Note Added May 20, 2019}\label{note201905}
+
+This version fixes various small issues and added specific examples
+of forms (deduction form, inference form, and closed form).
 
 \chapter{Introduction}
 \pagenumbering{arabic}
@@ -2946,7 +2951,7 @@ formally proven with Metamath:
 \item 54. The Konigsberg Bridge Problem
   (\texttt{konigsberg}, by Mario Carneiro, 2015-04-16)
 \item 83. The Friendship Theorem
-  (\texttt{friendship}, by Alexander van der Vekens, 2018-10-09)
+  (\texttt{friendship}, by Alexander W. van der Vekens, 2018-10-09)
 \end{itemize}
 \end{flushleft}
 


### PR DESCRIPTION
This adds the middle initial of Alexander W. van der Vekens,
adds a little information about the changes, and switches the
publish date to May 20, 2019.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>