### PR TITLE
Change generate-pdf to make style changes easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,9 @@ note = {{\tt http://us.metamath.org/downloads/metamath.pdf}},
 
 ## Narrow width screens
 
-You can run `./make-narrow` to generate "metamath-narrow.pdf",
+You can run `./generate-pdf narrow` to generate "metamath-narrow.pdf",
 a version of the PDF formatted for
 narrow-width screens such as mobile phones.
-The program erases metamath.pdf, so you'll need to regenerate metamath.pdf
-afterwards if you want it also.
-The program also manipulates some files, so you need to run these
-programs sequentially (one at a time) if you are running them in the
-same directory.
 
 The narrow version is based on
 an old version of this book that was generated specifically for

--- a/generate-pdf
+++ b/generate-pdf
@@ -4,30 +4,49 @@
 # Stop processing if error occurs (-e) and show what we're doing (-x)
 set -ex
 
+style="${1:-normal}"
+style="${style%.sty}"
+
+texfile="${2:-metamath}"
+texfile="${texfile%.tex}"
+
+if [ "$style" == 'normal' ]; then
+  outfile="$texfile"
+else
+  outfile="${texfile}-${style}"
+fi
+# Try to remove output .pdf first - if we can't, no point in going further.
+rm -f "${outfile}.pdf"
+
 # Run pdflatex on $1.
 # TODO: Add -output-directory _build
 do_pdflatex () {
   pdflatex -halt-on-error -interaction=nonstopmode "$1"
 }
 
-# Try to remove metamath.pdf first - if we can't, no point in going further.
-rm -f metamath.pdf
+# Set up temporary directory
+tempdir="temp-$outfile"
+rm -fr "$tempdir"
+mkdir -p "$tempdir"
+cp -p "${texfile}.tex" "$tempdir"
+cp -p "${style}.sty" "$tempdir/special-settings.sty"
 
-# Clean up
-rm -f realref.sty metamath.bib
+cd "temp-$outfile"
 touch metamath.ind
 
-do_pdflatex metamath
-do_pdflatex metamath
-bibtex metamath
-makeindex metamath
-do_pdflatex metamath
-do_pdflatex metamath
+do_pdflatex "$texfile"
+do_pdflatex "$texfile"
+bibtex "$texfile"
+makeindex "$texfile"
+do_pdflatex "$texfile"
+do_pdflatex "$texfile"
 
 # Print errors not already allowed; return error code if there are any
-if ! grep -Ei '(Error|Warning):' metamath.log | grep -vF -f allowed-errors
+if ! grep -Ei '(Error|Warning):' "$texfile.log" | grep -vF -f ../allowed-errors
 then
   echo 'PDF generation successful.'
 else
   exit 1 # fail
 fi
+
+cp -p "${texfile}.pdf" "../${outfile}.pdf"

--- a/generate-pdf
+++ b/generate-pdf
@@ -40,6 +40,7 @@ bibtex "$texfile"
 makeindex "$texfile"
 do_pdflatex "$texfile"
 do_pdflatex "$texfile"
+do_pdflatex "$texfile"
 
 # Print errors not already allowed; return error code if there are any
 if ! grep -Ei '(Error|Warning):' "$texfile.log" | grep -vF -f ../allowed-errors

--- a/generate-pdf
+++ b/generate-pdf
@@ -46,6 +46,8 @@ if ! grep -Ei '(Error|Warning):' "$texfile.log" | grep -vF -f ../allowed-errors
 then
   echo 'PDF generation successful.'
 else
+  echo "Failed.  Here's a list of labels that changed:"
+  egrep -A2 "label .* changed:" *.log
   exit 1 # fail
 fi
 

--- a/make-narrow
+++ b/make-narrow
@@ -2,10 +2,4 @@
 # Make metamath-narrow.pdf
 # WARNING: This erases metamath.pdf and special-settings.sty
 
-cp -p narrow.sty special-settings.sty
-
-./generate-pdf
-mv metamath.pdf metamath-narrow.pdf
-
-rm -f special-settings.sty
-touch special-settings.sty
+./generate-pdf narrow

--- a/metamath.tex
+++ b/metamath.tex
@@ -13220,7 +13220,7 @@ symbol representation.
 
 A statement's comment can include a special notation that provides a
 certain amount of control over the {\sc HTML} version of the comment.  See
-Section~\ref{mathcomments} (p.~\pageref{htmlmkup}) for the comment
+Section~\ref{mathcomments} (p.~\pageref{mathcomments}) for the comment
 markup features.
 
 The \texttt{write theorem{\char`\_}list} and \texttt{write bibliography}
@@ -13271,7 +13271,7 @@ filename}\texttt{{\char`\~}1}.
 A bibliographic reference is indicated with the reference name
 in brackets, such as  \texttt{Theorem 3.1 of
 [Monk] p.\ 22}.
-See Section~\ref{htmlmkup} (p.~\pageref{htmlmkup}) for
+See Section~\ref{htmlout} (p.~\pageref{htmlout}) for
 syntax details.
 
 


### PR DESCRIPTION
Change "generate-pdf" so that it creates a temporary directory,
copies the style and .tex files into it, and does all processing there.

This make it much easier to experiment with different styles,
eliminates a weird dependency (creating "narrow" would silently erase
the normal file), and eliminates problems from multithreading.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>