### PR TITLE
Document that David A. Wheeler's employer has ok'ed this

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -22,7 +22,12 @@
 % Norman Megill - email: nm(at)alum(dot)mit(dot)edu
 %
 % David A. Wheeler also donates his improvements to this file to the
-% public domain.
+% public domain per the CC0.  He works at the Institute for Defense Analyses
+% (IDA), but IDA has agreed that this Metamath work is outside its "lane"
+% and is not a work by IDA.  This was specifically confirmed by
+% Margaret E. Myers (Division Director of the Information Technology
+% and Systems Division) on 2019-05-24 and by Ben Lindorf (General Counsel)
+% on 2019-05-22.
 
 % This file, 'metamath.tex', is self-contained with everything needed to
 % generate the the PDF file 'metamath.pdf' (the _Metamath_ book) on


### PR DESCRIPTION
Add some legal information so that there is *no* question
about its (lack of) copyright.

David A. Wheeler developed the Metamath book improvements
(and various other Metamath works) on his own time, but he
has an employer (IDA).  IDA formally agreed that this wasn't
an IDA work.

Document that fact here, including people's names, titles, and dates,
to provide strong evidence that this book is entirely clean
of any copyright problems.  We don't want copyright problems
to inhibit anyone from getting the book!

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>