### PR TITLE
Fix typos found by Benoît Jubin in chapter 2 pp48-76

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -3948,7 +3948,7 @@ The last step, 34, contains the statement that is being proved.
 Looking at a small piece of the proof, notice that steps 3 and 4 have
 established that
 \texttt{( t + 0 )} and \texttt{t} are \texttt{term}\,s, and step 5 makes use of steps 3 and
-4 to establish that \texttt{( t + 0 ) = t} is a \texttt{wff}.  Let us let Metamath
+4 to establish that \texttt{( t + 0 ) = t} is a \texttt{wff}.  Let Metamath
 itself tell us in detail what is happening in step 5.  Note that the
 ``target hypothesis'' refers to where step 5 is eventually used, i.e., in step
 34.
@@ -4053,7 +4053,7 @@ MM> show s
 STATEMENT, or SOURCE.
 \end{verbatim}
 
-If you don't what know argument to use as part of a command, type a
+If you don't know what argument to use as part of a command, type a
 \texttt{?}\index{\texttt{]}@\texttt{?}\ in command lines}\ at the
 argument position.  Metamath will tell you what it expected there.
 
@@ -5636,8 +5636,8 @@ the definition should not be {\em creative}\index{creative
 definition}\index{definition!creative}, that
 is it should not allow an expression that previously qualified as a wff but
 was not provable, to become provable.   Second, the definition should be {\em
-eliminable}\index{definition!eliminability}, that is there should exist an
-algorithmic method for proving any expression using the definition into
+eliminable}\index{definition!eliminability}, that is, there should exist an
+algorithmic method for converting any expression using the definition into
 a logically equivalent expression that previously qualified as a wff.
 
 In almost all cases below, definitions connect two expressions with either
@@ -5666,7 +5666,8 @@ meets the restrictions on the dummy variable imposed by \texttt{\$d} and
 (inverted tee, meaning logical ``false'') as $( \varphi \wedge \lnot \varphi
 )$, i.e.\ ``phi and not phi.''  Here $\varphi$ is effectively bound because the
 definition remains logically equivalent when we replace $\varphi$ with any
-other wff.  (We do not define $\perp$ in \texttt{set.mm}.)
+other wff.  (It is actually \texttt{df-fal}
+in \texttt{set.mm}, which defines $\perp$.)
 
 There are two cases where eliminating definitions is a little more
 complex.  These cases are the definitions \texttt{df-bi} and
@@ -5702,7 +5703,7 @@ a few simplifications such as discarding occurrences of $\lnot\lnot$ (double
 negation).
 
 In the definitions below, we have placed the {\sc ascii} Metamath source
-below each of the formulas to help you to become familiar with the
+below each of the formulas to help you become familiar with the
 notation in the database.  For simplicity, the necessary \texttt{\$f}
 and \texttt{\$d} statements are not shown.  If you are in doubt, use the
 \texttt{show statement}\index{\texttt{show statement} command} command
@@ -5873,8 +5874,9 @@ $[ y / x ] z \in x$ is the same as $z \in y$.
 The notation is different from the notation $\varphi ( x | y )$
 that is sometimes used, because the latter notation is ambiguous for us:
 for example, we don't know whether $\lnot \varphi ( x | y )$ is to be
-interpreted as $\lnot ( \varphi x | y )$ or $( \lnot \varphi x | y
-)$.\footnote{Because of the way we initially defined wffs, this is the case
+interpreted as $\lnot ( \varphi ( x | y ) )$ or
+$( \lnot \varphi ) ( x | y )$.\footnote{Because of the way
+we initially defined wffs, this is the case
 with any postfix connective\index{postfix connective} (one occurring after the
 symbols being connected) or infix connective\index{infix connective} (one
 occurring between the symbols being connected).  Metamath does not have a


### PR DESCRIPTION
Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>