### PR TITLE
Fix power class per Benoit's comments

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -6193,8 +6193,8 @@ Compare  Definition 5.14 of Takeuti and Zaring, p.~20.\label{df-nul}
 
 \noindent Define power class\index{power set}\index{power class}.  Definition 5.10 of
 Takeuti and Zaring, p.~17, but we also let it apply to proper classes.  (Note
-that \verb$P~$ is the symbol for calligraphic P, the tilde
-suggesting ``curly;'' see Appendix~\ref{ASCII}.)
+that \verb$~P$ is the symbol for calligraphic P, the tilde
+suggesting ``curly;'' see Appendix~\ref{ASCII}.)\label{df-pw}
 
 \vskip 0.5ex
 \setbox\startprefix=\hbox{\tt \ \ df-pw\ \$a\ }
@@ -6204,7 +6204,7 @@ suggesting ``curly;'' see Appendix~\ref{ASCII}.)
 \endm
 % Special incantation required to put ~ into the text
 \begin{mmraw}%
-|- P\char`\~~A = \{ x | x C\_ A \} \$.
+|- \char`\~P~A = \{ x | x C\_ A \} \$.
 \end{mmraw}
 
 \noindent Define the singleton of a class\index{singleton}.  Definition 7.1 of
@@ -13591,6 +13591,9 @@ if that is necessary for clarity.
 \texttt{(/)} & $ \varnothing $ &
   \hyperref[df-nul]{\texttt{df-nul}} &
   $ \varnothing $ is the empty set (aka null set). \\
+\texttt{\char`\~P} & $ \cal P $ &
+  \hyperref[df-pw]{\texttt{df-pw}} &
+  Power class. \\
 \texttt{<.\ A , B >.} & $\langle A , B \rangle$ &
   \hyperref[df-op]{\texttt{df-op}} &
   The ordered pair $\langle A , B \rangle$. \\


### PR DESCRIPTION
Power class used to be notated as P~, fix that to be ~P.
The discussion cites appendix A but it's not actually listed there;
fix that also.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>