### PR TITLE
Add missing "the" in defining class of ordinal numbers

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -6414,7 +6414,7 @@ definition on p.~468, Bell and Machover.
 |- ( Ord A <-> ( Tr A \TAND E We A ) ) \$.
 \end{mmraw}
 
-\noindent Define class of all ordinal numbers\index{ordinal number}.  An ordinal number is
+\noindent Define the class of all ordinal numbers\index{ordinal number}.  An ordinal number is
 a set that satisfies the ordinal predicate.  Definition 7.11 of Takeuti and
 Zaring, p.~38.
 


### PR DESCRIPTION
Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>