### PR TITLE
Rename "cross product" to "Cartesian product"

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -6476,8 +6476,9 @@ is meaningless when classes are proper.
 |- om = \{ x | ( Ord x \TAND A. y ( Lim y -> x e. y ) ) \} \$.
 \end{mmraw}
 
-\noindent Define the cross product\index{cross product} of two classes.  Definition 9.11
-of Quine, p.~64.
+\noindent Define the Cartesian product (also called the
+cross product)\index{Cartesian product}\index{cross product}
+of two classes.  Definition 9.11 of Quine, p.~64.
 
 \vskip 0.5ex
 \setbox\startprefix=\hbox{\tt \ \ df-xp\ \$a\ }


### PR DESCRIPTION
The term "Cartesian product" seems to be more a more
commonly used term for this concept, and it's unambiguous.
So switch to using the term "Cartesian product" as the primary term,
and mention that an alternative name for this is "cross product".
This is based on a comment from Benoit.

In particular, I think the term "cross product" is primarily used
for a *different* construct, specifically, it's a
a binary operation on two vectors in three-dimensional space.
For example, the Wikipedia article for "cross product" doesn't even
mention the cartesian product as a plausible alternative meaning:
https://en.wikipedia.org/wiki/Cross_product
We don't want to use confusing terminology.

If we do this, we should also modify set.mm to match.
However, we should do this anyway.  While the df-xp description
in set.mm uses the term "cross product", many other discussions
in set.mm use the term "Cartesian product" instead.
This change would make set.mm more self-consistent as well.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>