### PR TITLE
Use "/all" for older show proof examples

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -13158,9 +13158,9 @@ sequence of Metamath commands:
 read set.mm
 open tex example.tex
 show statement a1i /tex
-show proof a1i /lemmon/renumber/tex
+show proof a1i /all/lemmon/renumber/tex
 show statement uneq2 /tex
-show proof uneq2 /lemmon/renumber/tex
+show proof uneq2 /all/lemmon/renumber/tex
 close tex
 \end{verbatim}
 


### PR DESCRIPTION
Now that "/essential" is the default, you need "/all"
if you want that in "show proof".  Modify these examples
which didn't include "/all" before to be consistent with
the old semantics.  I don't think it matters in this case,
but they're useful examples of multiple options.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>