### PR TITLE
Expand discussion direct vs. recursive definitions

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -9592,7 +9592,7 @@ This statement has the obvious requirement that $z$ must be
 distinct\index{distinct variables} from $x$ in theorem \texttt{ax17eq} that
 states $x=y \rightarrow \forall z \, x=y$ (well, obvious if you're a logician,
 for otherwise we could conclude  $x=y \rightarrow \forall x \, x=y$, which is
-false when the free variables $x$ and $y$ are equal.).
+false when the free variables $x$ and $y$ are equal).
 
 Let's look at what happens if we edit the database to comment out this
 requirement.
@@ -11730,7 +11730,7 @@ definition even though the definition itself is typically simple to
 state.
 
 Metamath itself has no built-in technical limitation that prevents
-multiple-part recursive definitions in the traditional textbook style,
+multiple-part recursive definitions in the traditional textbook style.
 However, because the recursive definition requires advanced metalogic
 to justify, eliminating a recursive definition is very difficult and
 often not even shown in textbooks.
@@ -11754,13 +11754,13 @@ side.  Quine calls this form ``a genuine or direct definition'' \cite[p.
 174]{Quine}\index{Quine, Willard Van Orman}, which makes the definitions
 very easy to eliminate and the metalogic\index{metalogic} needed to
 justify them as simple as possible.
-Put another way, we had a philosophical goal of being able to
+Put another way, we had a goal of being able to
 eliminate all definitions with direct mechanical substitution and to
 verify easily the soundness of the definitions.
 
 \subsubsection{Example of direct definitions}
 
-We achieved this philosophical goal in almost all cases in \texttt{set.mm}.
+We achieved this goal in almost all cases in \texttt{set.mm}.
 Sometimes this makes the definitions more complex and less
 intuitive.
 For example, the traditional way to define addition of
@@ -11821,7 +11821,7 @@ defines a recursive definition generator on ${\rm On}$ (the class of ordinal
 numbers) with characteristic function $F$ and initial value $I$.
 This rather amazing operation allows us to define, with
 compact direct definitions, functions that are usually defined in
-textbooks only with indirect self-referencing recursive definitions.
+textbooks with recursive definitions.
 The price paid with our approach
 is the daunting complexity of our ${\rm rec}$ operation
 (especially when {\tt df-recs} that it is built on is also eliminated).
@@ -11847,13 +11847,13 @@ The definition of ${\rm rec}$ depends on ${\rm recs}$.
 New direct usage of the more powerful (and more primitive) ${\rm recs}$
 construct is discouraged, but it is available when needed.
 This
-define a function $\mathrm{recs} ( F )$ on ${\rm On}$, the class of ordinal
+defines a function $\mathrm{recs} ( F )$ on ${\rm On}$, the class of ordinal
 numbers, by transfinite recursion given a rule $F$ which sets the next
 value given all values so far.
 Unlike {\tt df-rdg} which restricts the
 update rule to use only the previous value, this version allows the
 update rule to use all previous values, which is why it is described
-as ``strong", although it is actually more primitive.  See {\tt
+as ``strong,'' although it is actually more primitive.  See {\tt
 recsfnon} and {\tt recsval} for the primary contract of this definition.
 It is defined as:
 
@@ -11873,10 +11873,7 @@ number}\index{addition}\index{recursive definition}\index{ordinal addition}
 The end result is the same, but we completely eliminate the rather complex
 metalogic that justifies the recursive definition.
 
-You may be surprised at the complexity of what
-seems like such a simple notion.
-For a mathematician,
-recursive definitions are often considered more efficient and intuitive than
+Recursive definitions are often considered more efficient and intuitive than
 direct ones once the metalogic has been learned or possibly just accepted as
 correct.  However, it was felt that direct definition in \texttt{set.mm}
 maximizes rigor by minimizing metalogic.  It can be eliminated effortlessly,
@@ -11884,11 +11881,9 @@ something that is difficult to do with a recursive definition.
 
 Again, Metamath itself has no built-in technical limitation that prevents
 multiple-part recursive definitions in the traditional textbook style.
-Instead, our philosophical goal is to eliminate all definitions with
+Instead, our goal is to eliminate all definitions with
 direct mechanical substitution and to verify easily the soundness of
 definitions.
-We believe the advantages of this approach to definitions
-outweigh its disadvantages.
 
 \subsection{Adding Constraints on Definitions}
 

--- a/metamath.tex
+++ b/metamath.tex
@@ -11721,16 +11721,30 @@ fragments to classical logic just by adding axioms are given in
 \subsection{The Approach to Definitions in \texttt{set.mm}}
 
 In set theory, recursive definitions define a newly introduced symbol in
-terms of itself.  The justification of recursive definitions, using
+terms of itself.
+The justification of recursive definitions, using
 several ``recursion theorems,'' is usually one of the first
 sophisticated proofs a student encounters when learning set theory, and
 there is a significant amount of implicit metalogic behind a recursive
 definition even though the definition itself is typically simple to
-state.  It is, however, possible to substitute one kind of complexity
+state.
+
+Metamath itself has no built-in technical limitation that prevents
+multiple-part recursive definitions in the traditional textbook style,
+However, because the recursive definition requires advanced metalogic
+to justify, eliminating a recursive definition is very difficult and
+often not even shown in textbooks.
+
+\subsubsection{Direct definitions instead of recursive definitions}
+
+It is, however, possible to substitute one kind of complexity
 for another.  We can eliminate the need for metalogical justification by
 defining the operation directly with an explicit (but complicated)
 expression, then deriving the recursive definition directly as a
-theorem, using a recursion theorem ``in reverse.''  We do this in
+theorem, using a recursion theorem ``in reverse.''
+The elimination
+of a direct definition is a matter of simple mechanical substitution.
+We do this in
 \texttt{set.mm}, as follows.
 
 In \texttt{set.mm} our goal was to introduce almost all definitions in
@@ -11740,10 +11754,16 @@ side.  Quine calls this form ``a genuine or direct definition'' \cite[p.
 174]{Quine}\index{Quine, Willard Van Orman}, which makes the definitions
 very easy to eliminate and the metalogic\index{metalogic} needed to
 justify them as simple as possible.
+Put another way, we had a philosophical goal of being able to
+eliminate all definitions with direct mechanical substitution and to
+verify easily the soundness of the definitions.
 
-We achieved this goal in almost all cases in \texttt{set.mm}.
+\subsubsection{Example of direct definitions}
+
+We achieved this philosophical goal in almost all cases in \texttt{set.mm}.
 Sometimes this makes the definitions more complex and less
-intuitive.  For example, the traditional way to define addition of
+intuitive.
+For example, the traditional way to define addition of
 natural numbers is to define an operation called {\em
 successor}\index{successor} (which means ``plus one'' and is denoted by
 ``${\rm suc}$''), then define addition recursively\index{recursive
@@ -11757,10 +11777,12 @@ set-theoretical expression that $m + n$ represents, that will work for
 any $m$ and $n$ and that does not have a $+$ sign on its right-hand
 side.  For a recursive definition like this not to be circular
 (creative), there are some hidden, underlying assumptions we must make,
-for example that the natural numbers have a certain kind of order.  In
-\texttt{set.mm} we chose to start with the direct (though complex and
+for example that the natural numbers have a certain kind of order.
+
+In \texttt{set.mm} we chose to start with the direct (though complex and
 nonintuitive) definition then derive from it the standard recursive
-definition.\footnote{The closed-form definition used in \texttt{set.mm}
+definition.
+For example, the closed-form definition used in \texttt{set.mm}
 for the addition operation on ordinals\index{ordinal
 addition}\index{addition!of ordinals} (of which natural numbers are a
 subset) is
@@ -11768,45 +11790,105 @@ subset) is
 \setbox\startprefix=\hbox{\tt \ \ df-oadd\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ \ \ }
 \startm
-\m{\vdash}\m{+_o}\m{=}\m{\{}\m{\langle}\m{\langle}\m{x}\m{,}\m{y}\m{\rangle}%
-\m{,}\m{z}\m{\rangle}\m{|}\m{(}\m{(}\m{x}\m{\in}\m{{\rm On}}\m{\wedge}\m{y}\m{%
-\in}\m{{\rm On}}\m{)}\m{\wedge}\m{z}\m{=}\m{(}\m{{\rm rec}}\m{(}\m{\{}\m{%
-\langle}\m{w}\m{,}\m{v}\m{\rangle}\m{|}\m{v}\m{=}\m{{\rm suc}}\m{w}\m{\}}\m{,}%
-\m{x}\m{)}\m{`}\m{y}\m{)}\m{)}\m{\}}
+\m{\vdash}\m{+_o}\m{=}\m{(}\m{x}\m{\in}\m{{\rm On}}\m{,}\m{y}\m{\in}\m{{\rm
+On}}\m{\mapsto}\m{(}\m{{\rm rec}}\m{(}\m{(}\m{z}\m{\in}\m{{\rm
+V}}\m{\mapsto}\m{{\rm suc}}\m{z}\m{)}\m{,}\m{x}\m{)}\m{`}\m{y}\m{)}\m{)}
 \endm
+\noindent which depends on ${\rm rec}$.
 
-\noindent Here, the abstraction class of nested ordered pairs\index{abstraction
-class!of nested ordered pairs} is defined by \texttt{df-oprab} in \texttt{set.mm},
-and ${\rm rec}$ is a ``recursion operator''\index{recursion operator} with
-the definition
+\subsubsection{Recursion operators}
 
-\setbox\startprefix=\hbox{\tt \ \ df-rfg\ \$a\ }
+The above definition of \texttt{df-oadd} depends on the definition of
+${\rm rec}$, a ``recursion operator''\index{recursion operator} with
+the definition \texttt{df-rdg}:
+
+\setbox\startprefix=\hbox{\tt \ \ df-rdg\ \$a\ }
 \setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ \ }
 \startm
-\m{\vdash}\m{{\rm rec}}\m{(}\m{F}\m{,}\m{A}\m{)}\m{=}\m{\bigcup}\m{\{}\m{f}%
-\m{|}\m{\exists}\m{x}\m{(}\m{x}\m{\in}\m{{\rm On}}\m{\wedge}\m{(}\m{f}\m{{%
-\rm Fn}}\m{x}\m{\wedge}\m{\forall}\m{y}\m{(}\m{y}\m{\in}\m{x}\m{\rightarrow}%
-\m{(}\m{f}\m{`}\m{y}\m{)}\m{=}\m{(}\m{\{}\m{\langle}\m{g}\m{,}\m{z}\m{\rangle}%
-\m{|}\m{(}\m{(}\m{g}\m{=}\m{\varnothing}\m{\wedge}\m{z}\m{=}\m{A}\m{)}\m{\vee}%
-\m{(}\m{\lnot}\m{(}\m{g}\m{=}\m{\varnothing}\m{\vee}\m{{\rm Lim}}\m{{\rm dom}}%
-\m{g}\m{)}\m{\wedge}\m{z}\m{=}\m{(}\m{F}\m{`}\m{(}\m{g}\m{`}\m{\bigcup}\m{{%
-\rm dom}}\m{g}\m{)}\m{)}\m{)}\m{\vee}\m{(}\m{{\rm Lim}}\m{{\rm dom}}\m{g}\m{%
-\wedge}\m{z}\m{=}\m{\bigcup}\m{{\rm ran}}\m{g}\m{)}\m{)}\m{\}}\m{`}\m{(}\m{f}%
-\m{\restriction}\m{y}\m{)}\m{)}\m{)}\m{)}\m{)}\m{\}}
+\m{\vdash}\m{{\rm
+rec}}\m{(}\m{F}\m{,}\m{I}\m{)}\m{=}\m{\mathrm{recs}}\m{(}\m{(}\m{g}\m{\in}\m{{\rm
+V}}\m{\mapsto}\m{{\rm if}}\m{(}\m{g}\m{=}\m{\varnothing}\m{,}\m{I}\m{,}\m{{\rm
+if}}\m{(}\m{{\rm Lim}}\m{{\rm dom}}\m{g}\m{,}\m{\bigcup}\m{{\rm
+ran}}\m{g}\m{,}\m{(}\m{F}\m{`}\m{(}\m{g}\m{`}\m{\bigcup}\m{{\rm
+dom}}\m{g}\m{)}\m{)}\m{)}\m{)}\m{)}\m{)}
 \endm
 
 \noindent which can be further broken down with definitions shown in
-Section~\ref{setdefinitions}.  You may be surprised at the complexity of what
-seems like such a simple notion.  From these definitions the simpler, more
-intuitive recursive definition is derived as a set of theorems.}\index{natural
+Section~\ref{setdefinitions}.
+
+This definition of ${\rm rec}$
+defines a recursive definition generator on ${\rm On}$ (the class of ordinal
+numbers) with characteristic function $F$ and initial value $I$.
+This rather amazing operation allows us to define, with
+compact direct definitions, functions that are usually defined in
+textbooks only with indirect self-referencing recursive definitions.
+The price paid with our approach
+is the daunting complexity of our ${\rm rec}$ operation
+(especially when {\tt df-recs} that it is built on is also eliminated).
+But once we get past this hurdle, definitions that would otherwise be
+recursive become relatively simple, as in for example {\tt oav}, from
+which we prove the recursive textbook definition as theorems {\tt oa0}, {\tt
+oasuc}, and {\tt oalim} (with the help of theorems {\tt rdg0}, {\tt rdgsuc},
+and {\tt rdglim2a}).  We can also restrict the ${\rm rec}$ operation to
+define otherwise recursive functions on the natural numbers $\omega$; see {\tt
+fr0g} and {\tt frsuc}.  Our ${\rm rec}$ operation apparently does not appear
+in published literature, although closely related is Definition 25.2 of
+[Quine] p. 177, which he uses to ``turn...a recursion into a genuine or
+direct definition" (p. 174).  Note that the ${\rm if}$ operations (see
+{\tt df-if}) select cases based on whether the domain of $g$ is zero, a
+successor, or a limit ordinal.
+
+An important use of this definition ${\rm rec}$ is in the recursive sequence
+generator {\tt df-seq} on the natural numbers (as a subset of the
+complex infinite sequences such as the factorial function {\tt df-fac} and
+integer powers {\tt df-exp}).
+
+The definition of ${\rm rec}$ depends on ${\rm recs}$.
+New direct usage of the more powerful (and more primitive) ${\rm recs}$
+construct is discouraged, but it is available when needed.
+This
+define a function $\mathrm{recs} ( F )$ on ${\rm On}$, the class of ordinal
+numbers, by transfinite recursion given a rule $F$ which sets the next
+value given all values so far.
+Unlike {\tt df-rdg} which restricts the
+update rule to use only the previous value, this version allows the
+update rule to use all previous values, which is why it is described
+as ``strong", although it is actually more primitive.  See {\tt
+recsfnon} and {\tt recsval} for the primary contract of this definition.
+It is defined as:
+
+\setbox\startprefix=\hbox{\tt \ \ df-recs\ \$a\ }
+\setbox\contprefix=\hbox{\tt \ \ \ \ \ \ \ \ \ \ \ \ \ }
+\startm
+\m{\vdash}\m{\mathrm{recs}}\m{(}\m{F}\m{)}\m{=}\m{\bigcup}\m{\{}\m{f}\m{|}\m{\exists}\m{x}\m{\in}\m{{\rm
+On}}\m{(}\m{f}\m{{\rm
+Fn}}\m{x}\m{\wedge}\m{\forall}\m{y}\m{\in}\m{x}\m{(}\m{f}\m{`}\m{y}\m{)}\m{=}\m{(}\m{F}\m{`}\m{(}\m{f}\m{\restriction}\m{y}\m{)}\m{)}\m{)}\m{\}}
+\endm
+
+\subsubsection{Closing comments on direct definitions}
+
+From these direct definitions the simpler, more
+intuitive recursive definition is derived as a set of theorems.\index{natural
 number}\index{addition}\index{recursive definition}\index{ordinal addition}
 The end result is the same, but we completely eliminate the rather complex
-metalogic that justifies the recursive definition.  (For a mathematician,
-recursive definitions are more efficient and intuitive than
+metalogic that justifies the recursive definition.
+
+You may be surprised at the complexity of what
+seems like such a simple notion.
+For a mathematician,
+recursive definitions are often considered more efficient and intuitive than
 direct ones once the metalogic has been learned or possibly just accepted as
 correct.  However, it was felt that direct definition in \texttt{set.mm}
 maximizes rigor by minimizing metalogic.  It can be eliminated effortlessly,
-something difficult to do with a recursive definition.)
+something that is difficult to do with a recursive definition.
+
+Again, Metamath itself has no built-in technical limitation that prevents
+multiple-part recursive definitions in the traditional textbook style.
+Instead, our philosophical goal is to eliminate all definitions with
+direct mechanical substitution and to verify easily the soundness of
+definitions.
+We believe the advantages of this approach to definitions
+outweigh its disadvantages.
 
 \subsection{Adding Constraints on Definitions}
 

--- a/metamath.tex
+++ b/metamath.tex
@@ -11819,11 +11819,11 @@ Section~\ref{setdefinitions}.
 This definition of ${\rm rec}$
 defines a recursive definition generator on ${\rm On}$ (the class of ordinal
 numbers) with characteristic function $F$ and initial value $I$.
-This rather amazing operation allows us to define, with
+This operation allows us to define, with
 compact direct definitions, functions that are usually defined in
 textbooks with recursive definitions.
 The price paid with our approach
-is the daunting complexity of our ${\rm rec}$ operation
+is the complexity of our ${\rm rec}$ operation
 (especially when {\tt df-recs} that it is built on is also eliminated).
 But once we get past this hurdle, definitions that would otherwise be
 recursive become relatively simple, as in for example {\tt oav}, from


### PR DESCRIPTION
I think trying to hide this important information in a footnote
doesn't work.  Definitions are vital in set.mm, and both the
philosophical justification and approach to using it needed more space.

This adds a much longer discussion about definitions, mostly
cribbed from text already in set.mm.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>