### PR TITLE
Document default starting column

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -12482,6 +12482,7 @@ Optional command qualifiers:
         If this qualifier is omitted, steps are indented in a tree format.
 
     \texttt{/start{\char`\_}column} {\em number} - Overrides the default column
+        (16)
         at which the formula display starts in a Lemmon-style display.  May be
         used only in conjunction with \texttt{/lemmon}.
 


### PR DESCRIPTION
I did some experiments and found that
'show proof 2p2e4 /start_column 16 /lemmon' produces the same
result as 'show proof 2p2e4 /lemmon'.
Thus, the default value for start_column is 16; document that.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>