### PR TITLE
Add discussion about CC in _V

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -7598,6 +7598,9 @@ axioms but have since been formally proven (with Metamath) to be redundant:
 \begin{itemize}
 \item
   $\mathbb{C} \in V$.
+  At one time this was listed as a ``complex number axiom''
+  However, this is not properly speaking a complex number axiom,
+  and in any case its proof uses axioms of set theory.
   Proven redundant by Mario Carneiro\index{Carneiro, Mario} on
   17-Nov-2014 (see \texttt{axcnex}).
 \item


### PR DESCRIPTION
@benjub commented:

> 91, -5: axiom $\C \in V$: use \mathrm{V}, but more importantly: remove
> this bullet point? (it is not properly speaking a complex number axiom,
> and accordingly, its proof uses axioms of set theory)

Fair point, but it was listed as a complex number axiom.
So I've instead added a discussion about this issue.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>