### PR TITLE
Change "stronger" to "weaker", fixes #145

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -14842,7 +14842,7 @@ not known whether they are independent (i.e.\ none is
 redundant) in the metalogical sense; specifically, whether any axiom (possibly
 with additional non-mandatory distinct-variable restrictions, for use with any
 dummy variables in its proof) is provable from the others.  Note that
-metalogical independence is a stronger requirement than independence in the
+metalogical independence is a weaker requirement than independence in the
 usual logical sense.  Not all of the above axioms are logically independent:
 for example, C9$'$ can be proved as a metatheorem from the others, outside the
 formal system, by combining the possible cases of distinct variables.


### PR DESCRIPTION
@benjub argued that this term should be "weaker" not "stronger" in
https://github.com/metamath/metamath-book/issues/145#issuecomment-495989192
as follows:

> We have two relations among sets of schemes: the traditional one, at
> the object level, let's call it entailment, and the one you defined,
> let's call it meta-entailment. As you noted, meta-entailment implies
> entailment (i.e. if one can prove a scheme from some set of schemes, at
> the meta-level, then at the object level, one can prove all instances
> of that scheme from all instances of this set of schemes). Therefore,
> metacompleteness of a set of schemes is a stronger property than
> completeness, and meta-independence is a weaker property than
> independence. Your example of ax-12 shows that meta-independence is
> actually strictly weaker than independence: ax-12 is meta-independent
> (as proved my Monk) but not independent. (Simple analogue: being a
> rectangle is a strictly weaker requirement than being a square.)

> What is certainly true, on a subjective level, is that the relation of
> meta-entailment is harder to grasp, and as a consequence, typical proofs
> of metacompleteness and of meta-independence will be "harder" to find.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>