### PR TITLE
Add missing negative sign (typo), fixes #187

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -2656,7 +2656,7 @@ it will respond with \texttt{\{\{n-\char`\>-2\}, \{n-\char`\>-1\},
 the time this version of Mathematica was released this fact was unknown.)  If
 you ask Maple\index{Maple} to \texttt{solve(x\^{ }2 = 2\^{ }x)} then
 \texttt{simplify(\{"\})}, it returns the solution set \texttt{\{2, 4\}}, apparently
-unaware that 0.7666647\ldots is also a solution.} While of course extremely
+unaware that $-0.7666647$\ldots is also a solution.} While of course extremely
 valuable in applied mathematics, computer algebra systems tend to be of little
 interest to the theoretical mathematician except as aids for exploring certain
 specific problems.


### PR DESCRIPTION
The answer should be -0.7666647...; somehow the negative
sign was missing.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>