### PR TITLE
Remove ambiguous "In the past century"

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -1424,7 +1424,7 @@ to decide in the same way, you decide I don't have any aptitude.
     \footnote{\cite{Davis}, p.~40.}\\
 \end{quotation}
 
-In the past century, brilliant mathematicians have discovered almost
+Brilliant mathematicians have discovered almost
 unimaginably profound results that rank among the crowning intellectual
 achievements of mankind.  However, there is a sense in which modern abstract
 mathematics is behind the times, stuck in an era before computers existed.


### PR DESCRIPTION
We don't need this ambiguous "In the past century" -
just remove it!

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>