### PR TITLE
Note that syl is most common in 2019, and note some counts

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -6940,10 +6940,13 @@ Whitehead and Russell call this ``the principle of the
 syllogism... because... the syllogism in Barbara is derived from them''
 \cite[quote after Theorem *2.06 p.~101]{PM}.
 Some authors call this law a ``hypothetical syllogism.''
-At the time of this writing it is the most commonly referenced assertion in the
-\texttt{set.mm} database.\footnote{
+As of 2019 \texttt{syl} is the most commonly referenced proven
+assertion in the \texttt{set.mm} database.\footnote{
 The Metamath program command \texttt{show usage}
 shows the number of references.
+On 2019-04-29 (commit 71cbbbdb387e) \texttt{syl} was directly referenced
+10,819 times. The second most commonly referenced proven assertion
+was \texttt{eqid}, which was directly referenced 7,738 times.
 }
 
 \vskip 2ex


### PR DESCRIPTION
The syl assertion is still the most common one.
Add the date and commit, as well as numbers to demonstrate the point.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>