### PR TITLE
Remove specific count of definitions

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -5721,7 +5721,8 @@ Quine \cite{Quine}\index{Quine, Willard Van Orman}, Bell and Machover
 Herbert B.}.  Our list of definitions is provided more for reference than as a
 learning aid.  However, by looking at a few of them you can gain a feel for
 how the hierarchy is built up.  The definitions are a representative sample of
-the 130 or so in \texttt{set.mm}, but they are complete with respect to the
+the many definitions
+in \texttt{set.mm}, but they are complete with respect to the
 theorem examples we will present in Section~\ref{sometheorems}.  Also, some are
 slightly different from, but logically equivalent to, the ones in \texttt{set.mm}
 (some of which have been revised over time to shorten them, for example).


### PR DESCRIPTION
The text said that, "The definitions are a representative sample
of the 130 or so in set.mm...", but as of today there are
774 definitions in set.mm not including mathboxes.

There's no reason to give any particular count of definitions,
so don't do it.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>