### PR TITLE
Add abstract, tweak book text to match

### DIFF
--- a/abstract.txt
+++ b/abstract.txt
@@ -1,0 +1,11 @@
+Metamath is a computer language and an associated computer program
+for archiving, verifying, and studying mathematical proofs.
+The Metamath language is simple and robust, with an
+almost total absence of hard-wired syntax, and we believe that it
+provides about the simplest possible framework that allows essentially all of
+mathematics to be expressed with absolute rigor.
+While simple, it is also powerful;
+the Metamath Proof Explorer (MPE) database has over 20,000 proven theorems
+and is one of the top systems in the "Formalizing 100 Theorems" challenge.
+This book explains the Metamath language and program, with specific
+emphasis on the fundamentals of the MPE database.

--- a/metamath.tex
+++ b/metamath.tex
@@ -971,7 +971,7 @@ Metamath with certain special sequences (axioms) that tell it what rules
 of inference are allowed.  Metamath is not limited to any specific field of
 mathematics.  The Metamath language is simple and robust, with an
 almost total absence of hard-wired syntax, and
-I\footnote{Unless otherwise noted, the words
+we\footnote{Unless otherwise noted, the words
 ``I,'' ``me,'' and ``my'' refer to Norman Megill\index{Megill, Norman}, while
 ``we,'' ``us,'' and ``our'' refer to Norman Megill and
 David A. Wheeler\index{Wheeler, David A.}.}


### PR DESCRIPTION
It's helpful to have an abstract (e.g., for the back of the book).
Here's a try at it, with a tweak to the main text to match.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>