### PR TITLE
Use curling double quotes in abstract

### DIFF
--- a/abstract.txt
+++ b/abstract.txt
@@ -6,6 +6,6 @@ provides about the simplest possible framework that allows essentially all of
 mathematics to be expressed with absolute rigor.
 While simple, it is also powerful;
 the Metamath Proof Explorer (MPE) database has over 20,000 proven theorems
-and is one of the top systems in the "Formalizing 100 Theorems" challenge.
+and is one of the top systems in the “Formalizing 100 Theorems” challenge.
 This book explains the Metamath language and program, with specific
 emphasis on the fundamentals of the MPE database.


### PR DESCRIPTION
This turns the abstract double-quotes into UTF-8 curling double quotes.

We want the abstract to look as nice as it can.
We would do this differently in LaTeX, but the expectation is that
the abstract will go to other places (such as the back of the book).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>