### PR TITLE
Missing bracket in ebnf

### DIFF
--- a/metamath.tex
+++ b/metamath.tex
@@ -15588,7 +15588,7 @@ COMPRESSED-PROOF-BLOCK ::= ([A-Z] | '?')+
 WHITESPACE ::= (_WHITECHAR+ | _COMMENT) -> SKIP
 
 /* Comments. $( ... $) and do not nest. */
-_COMMENT ::= '$(' (_WHITECHAR+ (PRINTABLE-SEQUENCE - '$)')*
+_COMMENT ::= '$(' (_WHITECHAR+ (PRINTABLE-SEQUENCE - '$)'))*
   _WHITECHAR+ '$)' _WHITECHAR
 
 /* Whitespace: (' ' | '\t' | '\r' | '\n' | '\f') */


### PR DESCRIPTION
There appears to be a close bracket missing from this Metamath Language EBNF.  It's a slightly confusing to look at because of course a Metamath comment has bracket literals in it in addition to the brackets being used to explicitly specify precedence in the EBNF.  Since we know what to expect from a Metamath comment the placement of the missing bracket shouldn't be too hard to check.

I assume the EBNF has been fed into a parser-generator at some point, and ideally I'd like to know where so I can check this 'fix' formally.  But that also raises the question of how the bracket could have gone missing... maybe when it was transposed to .tex?... or maybe EBNF is more forgiving about brackets than I imagine?...  Or maybe I'm completely mistaken about this whole thing?!

I'm going to post to the Google Group about (JavaScript/Nearley) parsers fairly soon so I'll mention this then.